### PR TITLE
[INPLACE-40] frontend 폴더 변경사항에 대한 CI/CD 추가

### DIFF
--- a/.github/workflows/front-ci-cd.yml
+++ b/.github/workflows/front-ci-cd.yml
@@ -1,0 +1,68 @@
+name: Frontend CI/CD for main branches
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'frontend/**'
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Prettier
+        run: npm run format -- --check
+
+      - name: Run Tests
+        run: npm test
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '22'
+      
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Build project
+        run: npm run build
+        env:
+          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+      
+      - name: Deploy to S3
+        run: |
+            # 두 버킷에 배포
+            aws s3 sync dist/ s3://inplace.my --delete
+            aws s3 sync dist/ s3://www.inplace.my --delete
+            # CloudFront 캐시 무효화 필수
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/*"


### PR DESCRIPTION
### ✨ 작업 내용
- frontend 폴더 변경사항에 대해서만 작동하는 CI/CD workflow 추가
  - 트리거 조건 정의 : `paths: - 'frontend/**'`
    -> `on`에서 `paths` 설정을 추가해서 frontend 폴더 내 파일이 변경되었을 때만 워크플로우가 실행되도록 설정
  - 실행 환경 정의 : `working-directory: ./frontend`
    -> 각 job의 명령어들이 실행될 기본 디렉토리를 frontend 폴더로 지정
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
