### PR TITLE
[INPLACE-43] 리뷰 작성 페이지에서 menuImgUrls가 없을 때 발생하는 TypeError 수정

### DIFF
--- a/frontend/src/components/Review/steps/CommentStep.tsx
+++ b/frontend/src/components/Review/steps/CommentStep.tsx
@@ -14,7 +14,7 @@ interface CommentStepProps {
     address: AddressInfo;
     influencerName: string;
     menuInfos: {
-      menuImgUrls: string[];
+      menuImgUrls?: string[];
     };
   };
 }
@@ -48,7 +48,7 @@ export default function CommentStep({ isLiked, onBack, onSubmit, placeInfo }: Co
 
       <PlaceSection>
         <ImageWrapper>
-          <FallbackImage src={placeInfo.menuInfos.menuImgUrls[0]} alt="Restaurant Menu" />
+          <FallbackImage src={placeInfo.menuInfos.menuImgUrls?.[0]} alt="Restaurant Menu" />
         </ImageWrapper>
         <PlaceInfo>
           <TextWrapper className="name">

--- a/frontend/src/components/Review/steps/RatingStep.tsx
+++ b/frontend/src/components/Review/steps/RatingStep.tsx
@@ -12,7 +12,7 @@ interface RatingStepProps {
     address: AddressInfo;
     influencerName: string;
     menuInfos: {
-      menuImgUrls: string[];
+      menuImgUrls?: string[];
     };
   };
 }
@@ -39,7 +39,7 @@ export default function RatingStep({ onSubmit, placeInfo }: RatingStepProps) {
       <PlaceSection>
         <ImageFrame>
           <ImageWrapper>
-            <FallbackImage src={placeInfo.menuInfos.menuImgUrls[0]} alt="Restaurant Menu" />
+            <FallbackImage src={placeInfo.menuInfos.menuImgUrls?.[0]} alt="Restaurant Menu" />
           </ImageWrapper>
         </ImageFrame>
         <PlaceInfo>


### PR DESCRIPTION
### ✨ 작업 내용
- 버그 내용: `menuImgUrls` 객체가 없는 (undefined)상태에서 배열 index[0]으로 접근하려 하자  TypeError가 발생해서 리뷰 작성 페이지가 렌더링되지 않음
- 버그 원인: 백엔드에서 받아오는 `menuInfos` 객체 내에서 `menuImgUrls`가 없는 케이스를 고려하지 못함
- 해결 방법: `menuImgUrls?.[0]`로 옵셔널 체이닝을 추가해서 undefined를 반환 시 FallbackImage가 대체 이미지를 표시하도록 수정
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
