### PR TITLE
[INPLACE-48] 프론트용 Test 서버 vercel로 배포 

### DIFF
--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -23,6 +23,7 @@ jobs:
         run: npm run format -- --check
       - name: Run Tests
         run: npm test
+
   build-and-deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -59,3 +60,23 @@ jobs:
             aws s3 sync dist/ s3://www.inplace.my --delete
             # CloudFront 캐시 무효화 필수
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths "/*"
+
+  sync-fork:
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: creates output
+        run: sh ./frontend/build.sh
+      - name: Pushes to fork repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.VERCEL_PAT }}
+        with:
+          source-directory: 'output'
+          destination-github-username: 'userjmmm'
+          destination-repository-name: 'inplace'
+          user-email: ${{ secrets.VERCEL_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ..
+mkdir output
+cp -R ./inplace/frontend/* ./output
+cp -R ./output ./inplace/frontend/

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "https://api.inplace.my/$1"
+    }
+  ]
+}


### PR DESCRIPTION
### ✨ 작업 내용

---

### ✨ 참고 사항
- organization의 레포지토리를 vercel로 연결하려면 무조건 유료 결제를 해야 했습니다. 따라서 제 `repository`로 fork한 다음 vercel에 배포하는 방식을 통해 무료로 배포했습니다.
- vercel의 배포 도메인은 현재 **production server**로 사용 중인 `api.inplace.my`와 달라 cors 오류가 발생해서 `vercel.json`에 프록시 설정을 해두었습니다.
- dev용 브랜치가 변경될 때마다 자동으로 동기화하기 위해 `front-ci-cd` workflow에 해당 내용을 추가했습니다.
  - 개인 레포지에 동기화시키기 위해 팀 레포의 github secrets에 제 `VERCEL_PAT`, `VERCEL_EMAIL`을 추가해둔 상태입니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close
