### PR TITLE
[INPLCAE-22] 좋아요한 인플루언서를 좋아요 해제해도 조회되는 문제 해결

### DIFF
--- a/backend/src/main/java/team7/inplace/user/application/UserService.java
+++ b/backend/src/main/java/team7/inplace/user/application/UserService.java
@@ -49,7 +49,10 @@ public class UserService {
     @Transactional(readOnly = true)
     public List<Long> getInfluencerIdsByUsername(Long userId) {
         List<FavoriteInfluencer> likes = favoriteInfluencerRepository.findByUserId(userId);
-        return likes.stream().map(FavoriteInfluencer::getInfluencer).map(Influencer::getId)
+        return likes.stream()
+                .filter(FavoriteInfluencer::isLiked)
+                .map(FavoriteInfluencer::getInfluencer)
+                .map(Influencer::getId)
                 .toList();
     }
 


### PR DESCRIPTION
### ✨ 작업 내용

- UserService의 로직을 수정했습니다
- 기존 로직은 favoriteInfluencer에 존재하는 엔티티를 가져옴
- 수정 로직은 favoriteInfluencer에 존재하는 엔티티 중, liked가 True인 값만 가져옴

### ✨ 참고 사항

- 단순 로직 설계 문제

### ⏰ 현재 버그

---

### ✏ Git Close
