### PR TITLE
[INPLACE-89] 인증 상태 관련 로직 리팩터링

### DIFF
--- a/frontend/src/api/hooks/useGetRefreshToken.ts
+++ b/frontend/src/api/hooks/useGetRefreshToken.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { fetchInstance } from '../instance';
 
 export const getRefreshTokenPath = () => '/refresh-token';
@@ -9,8 +9,7 @@ export const getRefreshToken = async () => {
 };
 
 export const useGetRefreshToken = () => {
-  return useSuspenseQuery({
-    queryKey: ['refreshToken'],
-    queryFn: () => getRefreshToken(),
+  return useMutation({
+    mutationFn: () => getRefreshToken(),
   });
 };

--- a/frontend/src/api/hooks/useGetUserInfo.ts
+++ b/frontend/src/api/hooks/useGetUserInfo.ts
@@ -1,35 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { AxiosError, isAxiosError } from 'axios';
 import { fetchInstance } from '../instance';
 import { UserInfoData } from '@/types';
 
 export const getUserInfoPath = () => `/users/info`;
-
-interface ApiErrorResponse {
-  message: string;
-  code: string;
-  status: number;
-}
-
-export const isAuthorizationError = (
-  error: unknown,
-): error is AxiosError<ApiErrorResponse> & {
-  response: NonNullable<AxiosError<ApiErrorResponse>['response']>;
-} => {
-  if (!isAxiosError(error)) return false;
-  if (!error.response) return false;
-
-  return (
-    error.response.status === 401 && error.response.data !== undefined && typeof error.response.data.code === 'string'
-  );
-};
-
-interface QueryOptions {
-  retry?: boolean | number;
-  enabled?: boolean;
-  onError?: (error: unknown) => void;
-  onSuccess?: (data: UserInfoData) => void;
-}
 
 export const getUserInfo = async () => {
   try {
@@ -43,12 +16,12 @@ export const getUserInfo = async () => {
   }
 };
 
-export const useGetUserInfo = (options: QueryOptions = {}) => {
-  return useQuery<UserInfoData, unknown>({
+export const useGetUserInfo = () => {
+  return useQuery<UserInfoData>({
     queryKey: ['UserInfo'],
     queryFn: () => getUserInfo(),
+    staleTime: 2.9 * 60 * 1000,
     retry: false,
-    staleTime: 5 * 60 * 1000,
-    ...options,
+    throwOnError: false,
   });
 };

--- a/frontend/src/pages/Auth/index.tsx
+++ b/frontend/src/pages/Auth/index.tsx
@@ -26,7 +26,7 @@ export default function AuthPage() {
           navigate('/', { replace: true });
         }
       } else if (isAuthenticated) {
-        navigate('/choice', { replace: true });
+        navigate('/', { replace: true });
       }
     };
 

--- a/frontend/src/provider/Auth/index.tsx
+++ b/frontend/src/provider/Auth/index.tsx
@@ -14,7 +14,7 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-const ACCESS_TOKEN_REFRESH_INTERVAL = 9 * 60 * 1000;
+const ACCESS_TOKEN_REFRESH_INTERVAL = 3 * 60 * 1000;
 
 export default function AuthProvider({ children }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
@@ -47,7 +47,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         localStorage.setItem('nickname', userNickname);
         localStorage.setItem('isAuthenticated', 'true');
         setIsAuthenticated(true);
-        await refreshTokenRegularly();
+        setTimeout(() => refreshTokenRegularly(), ACCESS_TOKEN_REFRESH_INTERVAL);
       }
     },
     [isAuthenticated, refreshTokenRegularly],

--- a/frontend/src/provider/Auth/index.tsx
+++ b/frontend/src/provider/Auth/index.tsx
@@ -44,7 +44,6 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const handleLoginSuccess = useCallback(
     async (userNickname: string) => {
       if (!isAuthenticated) {
-        console.log('[AuthProvider] Setting login success for:', userNickname);
         localStorage.setItem('nickname', userNickname);
         localStorage.setItem('isAuthenticated', 'true');
         setIsAuthenticated(true);

--- a/frontend/src/provider/Auth/index.tsx
+++ b/frontend/src/provider/Auth/index.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useGetRefreshToken } from '@/api/hooks/useGetRefreshToken';
 import { useDeleteToken } from '@/api/hooks/useDeleteToken';
 
@@ -23,12 +24,14 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const { mutateAsync: refreshToken } = useGetRefreshToken();
   const { mutate: logout } = useDeleteToken();
+  const navigate = useNavigate();
 
   const handleLogout = useCallback(() => {
     logout();
     setIsAuthenticated(false);
     localStorage.removeItem('isAuthenticated');
     localStorage.removeItem('nickname');
+    navigate('/', { replace: true });
   }, [logout]);
 
   const refreshTokenRegularly = useCallback(async () => {

--- a/frontend/src/provider/Auth/index.tsx
+++ b/frontend/src/provider/Auth/index.tsx
@@ -1,5 +1,4 @@
 import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useGetRefreshToken } from '@/api/hooks/useGetRefreshToken';
 import { useDeleteToken } from '@/api/hooks/useDeleteToken';
 
@@ -15,7 +14,7 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-const ACCESS_TOKEN_REFRESH_INTERVAL = 3 * 60 * 1000;
+const ACCESS_TOKEN_REFRESH_INTERVAL = 11 * 60 * 1000;
 
 export default function AuthProvider({ children }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
@@ -24,14 +23,13 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const { mutateAsync: refreshToken } = useGetRefreshToken();
   const { mutate: logout } = useDeleteToken();
-  const navigate = useNavigate();
 
   const handleLogout = useCallback(() => {
-    logout();
     setIsAuthenticated(false);
     localStorage.removeItem('isAuthenticated');
     localStorage.removeItem('nickname');
-    navigate('/', { replace: true });
+    window.location.href = '/';
+    logout();
   }, [logout]);
 
   const refreshTokenRegularly = useCallback(async () => {

--- a/frontend/src/provider/Auth/index.tsx
+++ b/frontend/src/provider/Auth/index.tsx
@@ -14,7 +14,7 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-const ACCESS_TOKEN_REFRESH_INTERVAL = 11 * 60 * 1000;
+const ACCESS_TOKEN_REFRESH_INTERVAL = 3 * 60 * 1000;
 
 export default function AuthProvider({ children }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(

--- a/frontend/src/routes/component/PrivatedRoute.tsx
+++ b/frontend/src/routes/component/PrivatedRoute.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import useAuth from '@/hooks/useAuth';
 import LoginModal from '@/components/common/modals/LoginModal';
-import { useGetUserInfo, isAuthorizationError } from '@/api/hooks/useGetUserInfo';
+import { useGetUserInfo } from '@/api/hooks/useGetUserInfo';
 
 type PrivateRouteProps = {
   children: ReactElement;
@@ -22,45 +22,19 @@ export default function PrivateRoute({ children }: PrivateRouteProps) {
     isAuthenticated,
   });
 
-  const { data: userInfo, isLoading } = useGetUserInfo({
-    retry: false,
-    enabled: true,
-    onSuccess: (data) => {
-      if (data?.nickname && !isAuthenticated) {
-        handleLoginSuccess(data.nickname);
-      }
-    },
-    onError: (error: unknown) => {
-      console.log('Error occurred:', error);
-
-      if (isAuthorizationError(error)) {
-        console.log('[PrivateRoute] Unauthorized access:', {
-          message: error.response.data.message,
-          status: error.response.status,
-        });
-
-        if (isProtectedPath) {
-          navigate('/', { replace: true });
-        } else {
-          setShouldShowModal(true);
-        }
-        return;
-      }
-
-      console.error('사용자 정보 요청 실패:', error);
-      if (isProtectedPath) {
-        navigate('/', { replace: true });
-      } else {
-        setShouldShowModal(true);
-      }
-    },
-  });
+  const { data: userInfo, isLoading, isError } = useGetUserInfo();
 
   useEffect(() => {
+    if (isError) {
+      console.error('[PrivateRoute] Failed to fetch user info.');
+      navigate('/', { replace: true });
+      return;
+    }
+
     if (isProtectedPath && !isAuthenticated && !isLoading && !userInfo?.nickname) {
       navigate('/', { replace: true });
     }
-  }, [isProtectedPath, isAuthenticated, userInfo, isLoading, navigate]);
+  }, [isProtectedPath, isAuthenticated, userInfo, isLoading, isError, navigate]);
 
   const handleCloseModal = () => {
     if (window.history.length > 2) {

--- a/frontend/src/routes/component/PrivatedRoute.tsx
+++ b/frontend/src/routes/component/PrivatedRoute.tsx
@@ -18,11 +18,6 @@ export default function PrivateRoute({ children }: PrivateRouteProps) {
   const directRedirectPaths = ['/choice', '/auth'];
   const isProtectedPath = directRedirectPaths.includes(location.pathname);
 
-  console.log('[PrivateRoute] Current state:', {
-    path: location.pathname,
-    isAuthenticated,
-  });
-
   const { data: userInfo, isLoading, isError } = useGetUserInfo();
 
   useEffect(() => {

--- a/frontend/src/routes/component/PrivatedRoute.tsx
+++ b/frontend/src/routes/component/PrivatedRoute.tsx
@@ -10,6 +10,7 @@ type PrivateRouteProps = {
 
 export default function PrivateRoute({ children }: PrivateRouteProps) {
   const [shouldShowModal, setShouldShowModal] = useState(false);
+  const [isAccessChecked, setIsAccessChecked] = useState(false);
   const { isAuthenticated, handleLoginSuccess } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -25,6 +26,16 @@ export default function PrivateRoute({ children }: PrivateRouteProps) {
   const { data: userInfo, isLoading, isError } = useGetUserInfo();
 
   useEffect(() => {
+    const referer = document.referrer;
+    const isDirectAccess = !referer || referer.includes(window.location.origin) === false;
+
+    if (location.pathname === '/choice') {
+      if (isDirectAccess) {
+        navigate('/', { replace: true });
+        return;
+      }
+    }
+
     if (isError) {
       console.error('[PrivateRoute] Failed to fetch user info.');
       navigate('/', { replace: true });
@@ -33,6 +44,10 @@ export default function PrivateRoute({ children }: PrivateRouteProps) {
 
     if (isProtectedPath && !isAuthenticated && !isLoading && !userInfo?.nickname) {
       navigate('/', { replace: true });
+    }
+
+    if (!isLoading) {
+      setIsAccessChecked(true);
     }
   }, [isProtectedPath, isAuthenticated, userInfo, isLoading, isError, navigate]);
 
@@ -57,7 +72,7 @@ export default function PrivateRoute({ children }: PrivateRouteProps) {
     }
   }, [userInfo, isAuthenticated, handleLoginSuccess]);
 
-  if (isLoading) return null;
+  if (isLoading || !isAccessChecked) return null;
 
   if (shouldShowModal && !isAuthenticated) {
     return (


### PR DESCRIPTION
### ✨ 작업 내용
- [x] `access_token` 만료(3분)시 `refresh-token` API로 갱신 정상 동작
- [x] `refresh_token` 만료(10분)시 로그아웃 후 메인(/)으로 이동하도록 수정
- [x] 로그인 안 된 상태에서 `/auth`, `/choice`로 들어가면 메인(/)으로 이동하도록 수정
- [x] 로그인 된 상태에서 `/auth`, `/choice`로 직접 들어가면 메인(/)으로 이동하도록 수정
---

### ✨ 참고 사항
- 개발할 때 정상 동작하는 것을 확인했는데 방금 dev에 효은이 PR 올라가면서 로그인 리팩토링이 안 된 코드가 [개발 서버](https://ecalpni-dev.inplace.my/)에 들어가 있어! merge 전에 다시 내 코드 반영된 거로 올릴 수는 있는데, 머지되면 배포되기도 하고, 서버비 부담될까 봐 일단 안 올려뒀어..
 머지되기 전에 확인 하고 싶으면 가장 최신 커밋을 빌드해서 aws에서 직접 올리고 확인하면 될 듯! 아니면 머지되고 확인할 수 있을 거야

- 잘 동작하는지 확인하는 방법
1. 로그인 하기 전 `/auth`, `/choice`로 들어가면 메인(/)으로 이동되는지 확인
2. 첫 로그인 후 `/choice`로 리다이렉트 됐는지 확인(`request header`에 프론트 dev 주소 존재)
  : 참고로 시작하기 버튼을 누르면, 백엔드가 아직 수정 안 돼서 좋아요 반영 안 될 것임
3. 로그인 된 상태에서 `/auth`, `/choice`로 들어가면 메인(/)으로 이동되는지 확인
4. 로그인 후 3분마다 `/refresh-token` get 요청이 성공하고, `application > cookies`에서 값이 바뀌었나 확인
5. 로그인 후 탭을 닫은 다음 11분 뒤에 들어가면 로그아웃됐는지 확인
---

### ⏰ 현재 버그

---

### ✏ Git Close
