### PR TITLE
[INPLACE-170] 라이트 모드 테마 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import AuthPage from '@/pages/Auth';
 
 import GlobalStyle from './global';
 import MainPage from './pages/Main';
+import ThemeProvider from './provider/Themes';
 
 const DetailPage = lazy(() => import('@/pages/Detail'));
 const InfluencerPage = lazy(() => import('@/pages/Influencer'));
@@ -20,7 +21,7 @@ const NotFoundPage = lazy(() => import('@/pages/NotFound'));
 
 function App() {
   return (
-    <>
+    <ThemeProvider>
       <GlobalStyle />
       <AuthProvider>
         <Routes>
@@ -60,7 +61,7 @@ function App() {
           {/* <Route path="/reviews/:uuid" element={<ReviewPage />} /> */}
         </Routes>
       </AuthProvider>
-    </>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/Detail/GoogleReviewList.tsx
+++ b/frontend/src/components/Detail/GoogleReviewList.tsx
@@ -16,12 +16,12 @@ export default function GoogleReviewList({ lists }: { lists: GoogleReview[] }) {
             <GoogleReviewItem key={list.name}>
               <Title>
                 <Name>
-                  <Text size="xs" weight="bold" variant="white">
+                  <Text size="xs" weight="bold">
                     {list.name}
                   </Text>
                   {list.like ? <AiFillLike size={22} color="#fe7373" /> : <AiFillDislike size={22} color="#6F6CFF" />}
                 </Name>
-                <Text size="xs" weight="normal" variant="white">
+                <Text size="xs" weight="normal">
                   {new Date(list.publishTime).toLocaleDateString()}
                 </Text>
               </Title>

--- a/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
+++ b/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { LuParkingCircle, LuParkingCircleOff, LuParkingSquare, LuParkingSquareOff } from 'react-icons/lu';
 import { TbDisabled } from 'react-icons/tb';
 import styled from 'styled-components';
@@ -7,33 +8,40 @@ import { CiCreditCard1, CiCreditCardOff } from 'react-icons/ci';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import { FacilityInfo } from '@/types';
 import NoItem from '@/components/common/layouts/NoItem';
-
-const facilities = {
-  acceptsCreditCards: {
-    icon: { true: <CiCreditCard1 size={34} color="white" />, false: <CiCreditCardOff size={36} color="white" /> },
-    label: '카드결제',
-  },
-  freeParkingLot: {
-    icon: {
-      true: <LuParkingCircle size={60} color="white" strokeWidth={1} />,
-      false: <LuParkingCircleOff size={60} color="white" strokeWidth={1} />,
-    },
-    label: '무료주차',
-  },
-  paidParkingLot: {
-    icon: {
-      true: <LuParkingSquare size={60} color="white" strokeWidth={1} />,
-      false: <LuParkingSquareOff size={60} color="white" strokeWidth={1} />,
-    },
-    label: '유료주차',
-  },
-  wheelchairAccessibleSeating: {
-    icon: { true: <TbDisabled size={34} color="white" strokeWidth={1} />, false: null },
-    label: '휠체어좌석',
-  },
-};
+import { ThemeContext } from '@/provider/Themes';
 
 export default function FacilitySign({ category, facilityInfo }: { facilityInfo: FacilityInfo; category: string }) {
+  const { theme } = useContext(ThemeContext);
+  const iconVariant = theme === 'dark' ? 'white' : 'black';
+
+  const facilities = {
+    acceptsCreditCards: {
+      icon: {
+        true: <CiCreditCard1 size={34} color={iconVariant} />,
+        false: <CiCreditCardOff size={36} color={iconVariant} />,
+      },
+      label: '카드결제',
+    },
+    freeParkingLot: {
+      icon: {
+        true: <LuParkingCircle size={60} color={iconVariant} strokeWidth={1} />,
+        false: <LuParkingCircleOff size={60} color={iconVariant} strokeWidth={1} />,
+      },
+      label: '무료주차',
+    },
+    paidParkingLot: {
+      icon: {
+        true: <LuParkingSquare size={60} color={iconVariant} strokeWidth={1} />,
+        false: <LuParkingSquareOff size={60} color={iconVariant} strokeWidth={1} />,
+      },
+      label: '유료주차',
+    },
+    wheelchairAccessibleSeating: {
+      icon: { true: <TbDisabled size={34} color={iconVariant} strokeWidth={1} />, false: null },
+      label: '휠체어좌석',
+    },
+  };
+
   if (!facilityInfo) {
     return (
       <Wrapper>
@@ -41,6 +49,7 @@ export default function FacilitySign({ category, facilityInfo }: { facilityInfo:
       </Wrapper>
     );
   }
+
   return (
     <Wrapper>
       {Object.keys(facilityInfo).length === 0 ? (
@@ -50,11 +59,7 @@ export default function FacilitySign({ category, facilityInfo }: { facilityInfo:
           {category && (
             <SignWrapper>
               <Sign>
-                {category === '카페' ? (
-                  <IoCafeOutline size={34} color="white" />
-                ) : (
-                  <ImSpoonKnife size={30} color="white" />
-                )}
+                {category === '카페' ? <IoCafeOutline size={34} /> : <ImSpoonKnife size={30} color={iconVariant} />}
               </Sign>
               <Paragraph size="xs" weight="bold" variant="mint">
                 {category}
@@ -102,7 +107,7 @@ const Wrapper = styled.div`
 `;
 
 const Sign = styled.div`
-  border: 3px solid white;
+  border: 3px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : 'black')};
   width: 46px;
   height: 46px;
   border-radius: 50%;
@@ -114,7 +119,7 @@ const Sign = styled.div`
   @media screen and (max-width: 768px) {
     width: 40px;
     height: 40px;
-    border: 2px solid white;
+    border: 2px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : 'black')};
 
     svg {
       width: 30px;

--- a/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
+++ b/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
@@ -12,7 +12,7 @@ import { ThemeContext } from '@/provider/Themes';
 
 export default function FacilitySign({ category, facilityInfo }: { facilityInfo: FacilityInfo; category: string }) {
   const { theme } = useContext(ThemeContext);
-  const iconVariant = theme === 'dark' ? 'white' : 'black';
+  const iconVariant = theme === 'dark' ? 'white' : '#333333';
 
   const facilities = {
     acceptsCreditCards: {
@@ -107,7 +107,7 @@ const Wrapper = styled.div`
 `;
 
 const Sign = styled.div`
-  border: 3px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : 'black')};
+  border: 3px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : '#333333')};
   width: 46px;
   height: 46px;
   border-radius: 50%;
@@ -119,7 +119,7 @@ const Sign = styled.div`
   @media screen and (max-width: 768px) {
     width: 40px;
     height: 40px;
-    border: 2px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : 'black')};
+    border: 2px solid ${({ theme }) => (theme.textColor === '#ffffff' ? 'white' : '#333333')};
 
     svg {
       width: 30px;

--- a/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
+++ b/frontend/src/components/Detail/InfoTap/FacilitySign.tsx
@@ -76,7 +76,7 @@ export default function FacilitySign({ category, facilityInfo }: { facilityInfo:
             return (
               <SignWrapper key={key} $isParking={key.includes('Parking')}>
                 {key.includes('Parking') ? iconElement : <Sign>{iconElement}</Sign>}
-                <Paragraph size="xs" weight="normal" variant="white">
+                <Paragraph size="xs" weight="normal">
                   {label}
                 </Paragraph>
               </SignWrapper>

--- a/frontend/src/components/Detail/InfoTap/OpenHour.tsx
+++ b/frontend/src/components/Detail/InfoTap/OpenHour.tsx
@@ -13,7 +13,7 @@ export default function OpenHour({ openHour }: { openHour: string[] }) {
         <HourItem>
           {openHour.map((period) => (
             <TimeItem key={period}>
-              <Text size="xs" weight="normal" variant="white">
+              <Text size="xs" weight="normal">
                 {period}
               </Text>
             </TimeItem>

--- a/frontend/src/components/Detail/InfoTap/ReviewComment.tsx
+++ b/frontend/src/components/Detail/InfoTap/ReviewComment.tsx
@@ -19,7 +19,7 @@ export default function GoogleReviewComment({ text }: { text: string }) {
   const truncatedText = text.length > slice ? `${text.slice(0, slice)}...` : text;
 
   return (
-    <Paragraph size="xs" weight="normal" variant="white">
+    <Paragraph size="xs" weight="normal">
       {isExpanded ? text : truncatedText}
       {text.length > slice && !isExpanded && <MoreLink onClick={() => setIsExpanded(true)}>더보기</MoreLink>}
       {isExpanded && <MoreLink onClick={() => setIsExpanded(false)}>간략히</MoreLink>}

--- a/frontend/src/components/Detail/InfoTap/index.tsx
+++ b/frontend/src/components/Detail/InfoTap/index.tsx
@@ -62,7 +62,7 @@ export default function InfoTap({
     <Wrapper>
       <ButtonWrapper>
         {!isMobile ? (
-          <StyledButton aria-label="mobile_qr_btn" variant="outline" onClick={() => setVisitModal(!visitModal)}>
+          <StyledButton aria-label="mobile_qr_btn" variant="blackOutline" onClick={() => setVisitModal(!visitModal)}>
             <IoQrCode size={16} color="fee500" />
             모바일로 연결
           </StyledButton>
@@ -70,7 +70,7 @@ export default function InfoTap({
         <WebMap>
           <StyledButton
             aria-label="kakao_btn"
-            variant="outline"
+            variant="blackOutline"
             onClick={() => {
               window.location.href = kakaoPlaceUrl;
             }}
@@ -81,7 +81,7 @@ export default function InfoTap({
           {googlePlaceUrl ? (
             <StyledButton
               aria-label="google_btn"
-              variant="outline"
+              variant="blackOutline"
               onClick={() => {
                 window.location.href = googlePlaceUrl;
               }}

--- a/frontend/src/components/Detail/InfoTap/index.tsx
+++ b/frontend/src/components/Detail/InfoTap/index.tsx
@@ -94,19 +94,19 @@ export default function InfoTap({
       </ButtonWrapper>
       {googlePlaceUrl ? (
         <>
-          <Paragraph size="s" weight="bold" variant="white">
+          <Paragraph size="s" weight="bold">
             시설 정보
           </Paragraph>
           <FacilitySign category={category} facilityInfo={facility} />
-          <Paragraph size="s" weight="bold" variant="white">
+          <Paragraph size="s" weight="bold">
             운영 시간
           </Paragraph>
           <OpenHour openHour={openingHours} />
           <GoogleReviewTitle>
-            <StyledText size="s" weight="bold" variant="white">
+            <StyledText size="s" weight="bold">
               Google 리뷰
               <IoMdStar size={20} color="#FBBC04" />
-              <Text size="xs" weight="normal" variant="white">
+              <Text size="xs" weight="normal">
                 {rating}
               </Text>
             </StyledText>
@@ -134,7 +134,7 @@ export default function InfoTap({
           alignItems="center"
         />
       )}
-      <Paragraph size="s" weight="bold" variant="white">
+      <Paragraph size="s" weight="bold">
         지도 보기
       </Paragraph>
       <MapContainer>
@@ -220,7 +220,6 @@ const GoogleReviewTitle = styled.div`
 const StyledText = styled(Text)`
   display: flex;
   gap: 3px;
-  color: white;
   align-items: end;
   svg {
     margin-left: 10px;

--- a/frontend/src/components/Detail/InfoTap/index.tsx
+++ b/frontend/src/components/Detail/InfoTap/index.tsx
@@ -4,7 +4,7 @@ import { IoMdStar } from 'react-icons/io';
 import { IoQrCode } from 'react-icons/io5';
 import { FaComment } from 'react-icons/fa';
 import { FcGoogle } from 'react-icons/fc';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useContext, useEffect, useState } from 'react';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Paragraph } from '@/components/common/typography/Paragraph';
@@ -18,6 +18,7 @@ import NoItem from '@/components/common/layouts/NoItem';
 import VisitModal from '../VisitModal';
 import Loading from '@/components/common/layouts/Loading';
 import ErrorComponent from '@/components/common/layouts/Error';
+import { ThemeContext } from '@/provider/Themes';
 
 type Props = {
   category: string;
@@ -47,6 +48,8 @@ export default function InfoTap({
   const lng = Number(longitude);
   const [visitModal, setVisitModal] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+  const { theme } = useContext(ThemeContext);
+  const buttonVariant = theme === 'dark' ? 'outline' : 'blackOutline';
 
   useEffect(() => {
     const checkMobile = () => {
@@ -62,7 +65,7 @@ export default function InfoTap({
     <Wrapper>
       <ButtonWrapper>
         {!isMobile ? (
-          <StyledButton aria-label="mobile_qr_btn" variant="blackOutline" onClick={() => setVisitModal(!visitModal)}>
+          <StyledButton aria-label="mobile_qr_btn" variant={buttonVariant} onClick={() => setVisitModal(!visitModal)}>
             <IoQrCode size={16} color="fee500" />
             모바일로 연결
           </StyledButton>
@@ -70,7 +73,7 @@ export default function InfoTap({
         <WebMap>
           <StyledButton
             aria-label="kakao_btn"
-            variant="blackOutline"
+            variant={buttonVariant}
             onClick={() => {
               window.location.href = kakaoPlaceUrl;
             }}
@@ -81,7 +84,7 @@ export default function InfoTap({
           {googlePlaceUrl ? (
             <StyledButton
               aria-label="google_btn"
-              variant="blackOutline"
+              variant={buttonVariant}
               onClick={() => {
                 window.location.href = googlePlaceUrl;
               }}

--- a/frontend/src/components/Detail/ReviewTap/ReviewItem.tsx
+++ b/frontend/src/components/Detail/ReviewTap/ReviewItem.tsx
@@ -30,17 +30,17 @@ export default function ReviewItem({ reviewId, likes, comment, userNickname, cre
     <Wrapper>
       <Title>
         <Name>
-          <Text size="xs" weight="bold" variant="white">
+          <Text size="xs" weight="bold">
             {userNickname}
           </Text>
           {likes ? <AiFillLike size={22} color="#fe7373" /> : <AiFillDislike size={22} color="#6F6CFF" />}
         </Name>
-        <Text size="xs" weight="normal" variant="white">
+        <Text size="xs" weight="normal">
           {new Date(createdDate).toLocaleDateString()}
         </Text>
       </Title>
       <Comment>
-        <Paragraph size="xs" weight="normal" variant="white">
+        <Paragraph size="xs" weight="normal">
           {comment}
         </Paragraph>
         {mine ? (

--- a/frontend/src/components/Detail/ReviewTap/index.tsx
+++ b/frontend/src/components/Detail/ReviewTap/index.tsx
@@ -28,7 +28,7 @@ export default function ReviewTap({ placeLikes, id: placeId }: { placeLikes: Pla
         <BarGraph like={placeLikes.like} dislike={placeLikes.dislike} />
         <AiFillDislike size={50} color="#6F6CFF" />
       </CountLike>
-      <Paragraph size="m" weight="bold" variant="white">
+      <Paragraph size="m" weight="bold">
         <Text size="m" variant="mint" weight="bold">
           리뷰{' '}
         </Text>

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
@@ -324,10 +324,10 @@ const StyledBtn = styled(Button)`
 `;
 const Btn = styled.div`
   display: flex;
-  color: #c3c3c3;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#6f6f6f')};
   border-radius: 0px;
   font-size: 16px;
-  border-bottom: 0.5px solid #c3c3c3;
+  border-bottom: 0.5px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#6f6f6f')};
   width: fit-content;
   padding-bottom: 4px;
   gap: 6px;

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
@@ -275,7 +275,7 @@ export default function InfluencerMapWindow({
         </ResetButtonContainer>
         {!isListExpanded && (
           <ListViewButton onClick={onListExpand}>
-            <Text size="xs" variant="white" weight="normal">
+            <Text size="xs" weight="normal">
               목록 보기
             </Text>
           </ListViewButton>

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
@@ -275,7 +275,7 @@ export default function InfluencerMapWindow({
         </ResetButtonContainer>
         {!isListExpanded && (
           <ListViewButton onClick={onListExpand}>
-            <Text size="xs" weight="normal">
+            <Text size="xs" weight="normal" variant="white">
               목록 보기
             </Text>
           </ListViewButton>
@@ -293,6 +293,7 @@ const MapContainer = styled.div`
   position: relative;
   width: 100%;
   padding-bottom: 20px;
+  color: black;
 `;
 
 const ResetButtonContainer = styled.div`

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerPlaceSection.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerPlaceSection.tsx
@@ -220,10 +220,10 @@ const Btn = styled.div`
     display: flex;
     font-size: 14px;
   }
-  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#979797')};
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#6f6f6f')};
   border-radius: 0px;
   font-size: 16px;
-  border-bottom: 0.5px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#979797')};
+  border-bottom: 0.5px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#6f6f6f')};
   width: fit-content;
   gap: 6px;
   margin-bottom: 18px;

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerPlaceSection.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerPlaceSection.tsx
@@ -150,18 +150,12 @@ const SectionContainer = styled.div`
   box-sizing: content-box;
   &::-webkit-scrollbar {
     width: 8px;
-    color: #1f1f1f;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #1f1f1f;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#1f1f1f' : '#8e8e8e')};
     border-radius: 4px;
     border: none;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: #1f1f1f;
-    width: 8px;
   }
 
   &::-webkit-scrollbar-track {
@@ -226,11 +220,10 @@ const Btn = styled.div`
     display: flex;
     font-size: 14px;
   }
-
-  color: #c3c3c3;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#979797')};
   border-radius: 0px;
   font-size: 16px;
-  border-bottom: 0.5px solid #c3c3c3;
+  border-bottom: 0.5px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#c3c3c3' : '#979797')};
   width: fit-content;
   gap: 6px;
   margin-bottom: 18px;

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfoWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfoWindow.tsx
@@ -19,7 +19,7 @@ export default function InfoWindow({ data, onClose }: Props) {
   return (
     <Wrapper>
       <Title>
-        <Text size="xs" weight="bold" className="title">
+        <Text size="xs" weight="bold" variant="black" className="title">
           {data.placeName}
         </Text>
         {!isLongName && (

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/index.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/index.tsx
@@ -202,7 +202,7 @@ const MobilePlaceSection = styled.div<{ $translateY: number; $isExpanded: boolea
     width: 100%;
     transform: translateY(${(props) => props.$translateY}px);
     height: 80vh;
-    background-color: #3c3c3c;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#3c3c3c' : '#fafafa')};
     z-index: 90;
     border-top-left-radius: 16px;
     border-top-right-radius: 16px;

--- a/frontend/src/components/Main/InfluencerSection/index.tsx
+++ b/frontend/src/components/Main/InfluencerSection/index.tsx
@@ -105,10 +105,10 @@ const ArrowButton = styled.button<{ direction: 'left' | 'right' }>`
 
   &:hover {
     color: white;
-    background: ${({ direction }) =>
+    background: ${({ direction, theme }) =>
       direction === 'left'
-        ? 'linear-gradient(to right, rgba(0, 0, 0, 0.6), transparent 90%)'
-        : 'linear-gradient(to left, rgba(0, 0, 0, 0.6), transparent 90%)'};
+        ? `linear-gradient(to right, ${theme.backgroundColor === '#292929' ? 'rgba(0, 0, 0, 0.6)' : 'rgba(50, 50, 50, 0.3)'}, transparent 90%)`
+        : `linear-gradient(to left, ${theme.backgroundColor === '#292929' ? 'rgba(0, 0, 0, 0.6)' : 'rgba(50, 50, 50, 0.3)'}, transparent 90%)`};
   }
 
   &.left-arrow {

--- a/frontend/src/components/Main/SpotSection/SpotItem.tsx
+++ b/frontend/src/components/Main/SpotSection/SpotItem.tsx
@@ -23,10 +23,10 @@ export default function SpotItem({ videoId, videoAlias, videoUrl, place, isInflu
       <ImageWrapper $isInfluencer={isInfluencer}>
         <FallbackImage src={thumbnailUrl} alt={String(videoId)} />
       </ImageWrapper>
-      <Paragraph size="m" weight="bold" variant="white">
+      <Paragraph size="m" weight="bold">
         {videoAlias}
       </Paragraph>
-      <Paragraph size="xs" weight="normal" variant="white">
+      <Paragraph size="xs" weight="normal">
         <FaMapMarkerAlt size={20} color="#55EBFF" />
         {place.placeName}
       </Paragraph>
@@ -40,6 +40,7 @@ const Wrapper = styled(Link)<{ $isInfluencer: boolean }>`
   align-content: end;
   line-height: 30px;
   gap: 4px;
+  color: inherit;
 
   svg {
     margin-right: 2px;

--- a/frontend/src/components/Main/SpotSection/index.tsx
+++ b/frontend/src/components/Main/SpotSection/index.tsx
@@ -98,10 +98,10 @@ const ArrowButton = styled.button<{ direction: 'left' | 'right' }>`
 
   &:hover {
     color: white;
-    background: ${({ direction }) =>
+    background: ${({ direction, theme }) =>
       direction === 'left'
-        ? 'linear-gradient(to right, rgba(0, 0, 0, 0.6), transparent 90%)'
-        : 'linear-gradient(to left, rgba(0, 0, 0, 0.6), transparent 90%)'};
+        ? `linear-gradient(to right, ${theme.backgroundColor === '#292929' ? 'rgba(0, 0, 0, 0.6)' : 'rgba(50, 50, 50, 0.3)'}, transparent 90%)`
+        : `linear-gradient(to left, ${theme.backgroundColor === '#292929' ? 'rgba(0, 0, 0, 0.6)' : 'rgba(50, 50, 50, 0.3)'}, transparent 90%)`};
   }
 
   &.left-arrow {

--- a/frontend/src/components/Map/DropdownMenu/index.tsx
+++ b/frontend/src/components/Map/DropdownMenu/index.tsx
@@ -204,7 +204,7 @@ const DropdownButton = styled.button<{ $isOpen: boolean }>`
   cursor: pointer;
   font-weight: 700;
   font-size: 16px;
-  color: #004cff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#004cff' : '#3b63c3')};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -225,6 +225,7 @@ const DropdownMenuContainer = styled.div<{ $multiLevel: boolean; $hasSubOptions:
   left: 0;
   width: ${(props) => (props.$multiLevel && props.$hasSubOptions ? '200%' : '100%')};
   background: #ffffff;
+  color: black;
   border: 2px solid rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
   border-radius: 8px;
@@ -271,7 +272,7 @@ const SearchIcon = styled(FaSearch)`
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
-  color: #004cff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#004cff' : '#3b63c3')};
   cursor: pointer;
 
   @media screen and (max-width: 768px) {

--- a/frontend/src/components/Map/MapWindow/index.tsx
+++ b/frontend/src/components/Map/MapWindow/index.tsx
@@ -329,7 +329,7 @@ export default function MapWindow({
       </ResetButtonContainer>
       {!isListExpanded && (
         <ListViewButton onClick={onListExpand}>
-          <Text size="xs" variant="white" weight="normal">
+          <Text size="xs" weight="normal">
             목록 보기
           </Text>
         </ListViewButton>

--- a/frontend/src/components/Map/MapWindow/index.tsx
+++ b/frontend/src/components/Map/MapWindow/index.tsx
@@ -329,7 +329,7 @@ export default function MapWindow({
       </ResetButtonContainer>
       {!isListExpanded && (
         <ListViewButton onClick={onListExpand}>
-          <Text size="xs" weight="normal">
+          <Text size="xs" weight="normal" variant="white">
             목록 보기
           </Text>
         </ListViewButton>
@@ -342,6 +342,7 @@ const MapContainer = styled.div`
   position: relative;
   width: 100%;
   padding-bottom: 20px;
+  color: black;
 `;
 const LoadingWrapper = styled.div`
   position: absolute;

--- a/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
+++ b/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
@@ -109,12 +109,15 @@ const PlaceCard = styled.div<{ $isSelected: boolean }>`
   border-radius: 6px;
   padding: 16px;
   cursor: pointer;
-  background-color: ${({ $isSelected }) => ($isSelected ? '#1b1a1a' : 'none')};
+  background-color: ${({ $isSelected, theme }) => {
+    if ($isSelected) return theme.backgroundColor === '#292929' ? '#1b1a1a' : '#d5ecec';
+    return 'none';
+  }};
   transition: background-color 0.1s ease;
   box-sizing: border-box;
 
   &:hover {
-    background-color: #1b1a1a;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#1b1a1a' : '#d5ecec')};
   }
 
   @media screen and (max-width: 768px) {

--- a/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
+++ b/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
@@ -68,14 +68,14 @@ export default function PlaceItem({
           {/* <ImageContainer>
           <FallbackImage src={menuImgUrl} alt={placeName} />
         </ImageContainer> */}
-          <Text size="m" weight="bold" variant="white">
+          <Text size="m" weight="bold">
             {placeName}
           </Text>
-          <Text size="xs" weight="normal" variant="white">
+          <Text size="xs" weight="normal">
             {getFullAddress(address)}
           </Text>
           <InfluencerName>
-            <Text size="xs" weight="normal" variant="white">
+            <Text size="xs" weight="normal">
               {influencerName}
             </Text>
           </InfluencerName>
@@ -88,7 +88,7 @@ export default function PlaceItem({
           {isLike ? (
             <PiHeartFill color="#fe7373" size={30} data-testid="PiHeartFill" />
           ) : (
-            <PiHeartLight color="white" size={30} data-testid="PiHeartLight" />
+            <PiHeartLight size={30} data-testid="PiHeartLight" />
           )}
         </LikeIcon>
       </PlaceCard>

--- a/frontend/src/components/Map/PlaceSection/index.tsx
+++ b/frontend/src/components/Map/PlaceSection/index.tsx
@@ -143,18 +143,12 @@ const SectionContainer = styled.div`
   box-sizing: content-box;
   &::-webkit-scrollbar {
     width: 8px;
-    color: #1f1f1f;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #1f1f1f;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#1f1f1f' : '#8e8e8e')};
     border-radius: 4px;
     border: none;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: #1f1f1f;
-    width: 8px;
   }
 
   &::-webkit-scrollbar-track {

--- a/frontend/src/components/My/UserPlaceSection/UserPlaceItem.tsx
+++ b/frontend/src/components/My/UserPlaceSection/UserPlaceItem.tsx
@@ -86,7 +86,7 @@ const Wrapper = styled(Link)`
   color: inherit;
 
   &:hover {
-    background-color: #1b1a1a;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '1b1a1a' : '#d5ecec')};
   }
 `;
 

--- a/frontend/src/components/My/UserPlaceSection/UserPlaceItem.tsx
+++ b/frontend/src/components/My/UserPlaceSection/UserPlaceItem.tsx
@@ -54,18 +54,18 @@ export default function UserPlaceItem({ placeId, placeName, influencerName, like
     <>
       <Wrapper to={`/detail/${placeId}`}>
         <TextWrapper>
-          <Text className="overflow" size="m" weight="bold" variant="white">
+          <Text className="overflow" size="m" weight="bold">
             {placeName}
           </Text>
-          <Text className="overflow" size="xs" weight="normal" variant="white">
+          <Text className="overflow" size="xs" weight="normal">
             {getFullAddress(address)}
           </Text>
-          <Paragraph size="xs" weight="normal" variant="white">
+          <Paragraph size="xs" weight="normal">
             {influencerName}
           </Paragraph>
         </TextWrapper>
         <LikeIcon onClick={(e: React.MouseEvent<HTMLDivElement>) => handleClickLike(e)}>
-          {isLike ? <PiHeartFill color="#fe7373" size={26} /> : <PiHeartLight color="white" size={30} />}
+          {isLike ? <PiHeartFill color="#fe7373" size={26} /> : <PiHeartLight size={30} />}
         </LikeIcon>
       </Wrapper>
       {showLoginModal && (
@@ -83,6 +83,7 @@ const Wrapper = styled(Link)`
   border-radius: 4px;
   padding: 10px;
   justify-content: space-between;
+  color: inherit;
 
   &:hover {
     background-color: #1b1a1a;

--- a/frontend/src/components/My/UserReview/UserReviewItem.tsx
+++ b/frontend/src/components/My/UserReview/UserReviewItem.tsx
@@ -16,7 +16,7 @@ export default function UserReviewItem({ likes, comment, place, createdDate }: U
       </ImageContainer> */}
       <TextContainer>
         <Title>
-          <Text size="s" weight="bold" variant="white">
+          <Text size="s" weight="bold">
             {place.placeName}
           </Text>
           {likes ? <AiFillLike size={26} color="#fe7373" /> : <AiFillDislike size={26} color="#6F6CFF" />}
@@ -25,10 +25,10 @@ export default function UserReviewItem({ likes, comment, place, createdDate }: U
           {address}
         </Paragraph>
         <Title>
-          <Paragraph size="xs" weight="normal" variant="white">
+          <Paragraph size="xs" weight="normal">
             {comment}
           </Paragraph>
-          <Text size="xs" weight="normal" variant="white">
+          <Text size="xs" weight="normal">
             {new Date(createdDate).toLocaleDateString()}
           </Text>
         </Title>
@@ -41,6 +41,7 @@ const Wrapper = styled(Link)`
   display: flex;
   gap: 24px;
   align-items: center;
+  color: inherit;
 
   @media screen and (max-width: 768px) {
     gap: 14px;

--- a/frontend/src/components/My/UserReview/UserReviewList.tsx
+++ b/frontend/src/components/My/UserReview/UserReviewList.tsx
@@ -39,18 +39,12 @@ const ListContainer = styled.div`
   box-sizing: content-box;
   &::-webkit-scrollbar {
     width: 6px;
-    color: #1f1f1f;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #1f1f1f;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#1f1f1f' : '#8e8e8e')};
     border-radius: 4px;
     border: none;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: #1f1f1f;
-    width: 6px;
   }
 
   &::-webkit-scrollbar-track {

--- a/frontend/src/components/My/UserReview/index.tsx
+++ b/frontend/src/components/My/UserReview/index.tsx
@@ -47,7 +47,6 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  color: white;
 `;
 const LoadMoreTrigger = styled.div`
   display: flex;

--- a/frontend/src/components/My/infiniteBaseLayout.tsx
+++ b/frontend/src/components/My/infiniteBaseLayout.tsx
@@ -105,5 +105,4 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  color: white;
 `;

--- a/frontend/src/components/Review/steps/CommentStep.tsx
+++ b/frontend/src/components/Review/steps/CommentStep.tsx
@@ -22,16 +22,16 @@ export default function CommentStep({ isLiked, onBack, onSubmit, placeInfo }: Co
   return (
     <StepContainer>
       <TitleSection>
-        <Text size="l" weight="normal" variant="white">
+        <Text size="l" weight="normal">
           어떤 점이 {isLiked ? '좋으셨나요?' : '아쉬우셨나요?'}
         </Text>
       </TitleSection>
 
       <TextWrapper>
-        <Text size="l" weight="bold" variant="white">
+        <Text size="l" weight="bold">
           한 줄 리뷰
         </Text>
-        <Text size="l" weight="normal" variant="white">
+        <Text size="l" weight="normal">
           를 작성해주세요.&nbsp;
         </Text>
         <Text size="l" weight="normal" style={{ color: '#c6c6c6' }}>
@@ -53,7 +53,7 @@ export default function CommentStep({ isLiked, onBack, onSubmit, placeInfo }: Co
             </Text>
           </TextWrapper>
           <TextWrapper className="influencer">
-            <Text size="xs" weight="normal" variant="white">
+            <Text size="xs" weight="normal">
               {placeInfo.influencerName}
             </Text>
           </TextWrapper>

--- a/frontend/src/components/Review/steps/RatingStep.tsx
+++ b/frontend/src/components/Review/steps/RatingStep.tsx
@@ -44,7 +44,7 @@ export default function RatingStep({ onSubmit, placeInfo }: RatingStepProps) {
               </Text>
             </TextWrapper>
             <TextWrapper className="influencer">
-              <Text size="s" weight="normal" variant="white">
+              <Text size="s" weight="normal">
                 {placeInfo.influencerName}
               </Text>
             </TextWrapper>

--- a/frontend/src/components/common/BaseLayout.tsx
+++ b/frontend/src/components/common/BaseLayout.tsx
@@ -104,7 +104,6 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  color: white;
   width: 100%;
 `;
 

--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -73,7 +73,7 @@ const variantStyles = (variant: Props['variant'] = 'mint') => {
       background: 'none',
 
       '&:hover': {
-        backgroundColor: '#f4f4f4',
+        backgroundColor: '#d5ecec',
       },
     };
   }

--- a/frontend/src/components/common/Chip/index.tsx
+++ b/frontend/src/components/common/Chip/index.tsx
@@ -99,8 +99,8 @@ const FilterChip = styled.div`
   padding: 4px 10px 4px 18px;
   height: 24px;
   border-radius: 18px;
-  background-color: #e8f9ff;
-
+  background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#e8f9ff' : '#c9ebf1')};
+  color: black;
   @media screen and (max-width: 768px) {
     padding: 4px 10px 4px 14px;
     font-size: 14px;

--- a/frontend/src/components/common/InfluencerSearchBar.tsx
+++ b/frontend/src/components/common/InfluencerSearchBar.tsx
@@ -39,7 +39,7 @@ const SearchBarContainer = styled.div`
 const SearchInputWrapper = styled.div`
   display: flex;
   align-items: center;
-  background: #414141;
+  background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#414141' : '#ffffff')};
   padding: 12px 16px;
   border: 1.5px solid #a5a5a5;
   border-radius: 16px;
@@ -49,7 +49,7 @@ const SearchInputWrapper = styled.div`
 const SearchInput = styled.input`
   font-size: 16px;
   flex: 1;
-  color: #ffffff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
   background: transparent;
   border: none;
   margin-right: 8px;

--- a/frontend/src/components/common/Items/ChoiceItem.tsx
+++ b/frontend/src/components/common/Items/ChoiceItem.tsx
@@ -46,14 +46,14 @@ export default function ChoiceItem({
       <Wrapper>
         <ImageContainer>
           <LikeIcon onClick={handleClickLike}>
-            {isSelected ? <PiHeartFill color="#fe7373" size={32} /> : <PiHeartLight color="white" size={32} />}
+            {isSelected ? <PiHeartFill color="#fe7373" size={32} /> : <PiHeartLight size={32} />}
           </LikeIcon>
           <FallbackImage src={influencerImgUrl} alt={influencerName} />
         </ImageContainer>
-        <Paragraph size="m" weight="bold" variant="white">
+        <Paragraph size="m" weight="bold">
           {influencerName}
         </Paragraph>
-        <Paragraph size="xs" weight="normal" variant="white">
+        <Paragraph size="xs" weight="normal">
           {influencerJob}
         </Paragraph>
       </Wrapper>

--- a/frontend/src/components/common/Items/ChoiceItem.tsx
+++ b/frontend/src/components/common/Items/ChoiceItem.tsx
@@ -46,7 +46,7 @@ export default function ChoiceItem({
       <Wrapper>
         <ImageContainer>
           <LikeIcon onClick={handleClickLike}>
-            {isSelected ? <PiHeartFill color="#fe7373" size={32} /> : <PiHeartLight size={32} />}
+            {isSelected ? <PiHeartFill color="#fe7373" size={32} /> : <PiHeartLight size={32} color="white" />}
           </LikeIcon>
           <FallbackImage src={influencerImgUrl} alt={influencerName} />
         </ImageContainer>

--- a/frontend/src/components/common/Items/InfluencerItem.tsx
+++ b/frontend/src/components/common/Items/InfluencerItem.tsx
@@ -84,7 +84,7 @@ export default function InfluencerItem({
           {useBackCard && useNav && (
             <BackImageWrapper>
               <MdLocationOn size={50} color="#55EBFF" />
-              <Paragraph size="m" weight="bold">
+              <Paragraph size="m" weight="bold" variant="white">
                 지도 보기
               </Paragraph>
             </BackImageWrapper>

--- a/frontend/src/components/common/Items/InfluencerItem.tsx
+++ b/frontend/src/components/common/Items/InfluencerItem.tsx
@@ -84,17 +84,17 @@ export default function InfluencerItem({
           {useBackCard && useNav && (
             <BackImageWrapper>
               <MdLocationOn size={50} color="#55EBFF" />
-              <Paragraph size="m" variant="white" weight="bold">
+              <Paragraph size="m" weight="bold">
                 지도 보기
               </Paragraph>
             </BackImageWrapper>
           )}
         </ImageContainer>
         <TextWrapper>
-          <Paragraph size="m" weight="bold" variant="white">
+          <Paragraph size="m" weight="bold">
             {influencerName}
           </Paragraph>
-          <Paragraph size="xs" weight="normal" variant="white">
+          <Paragraph size="xs" weight="normal">
             {influencerJob}
           </Paragraph>
         </TextWrapper>
@@ -114,6 +114,7 @@ const Wrapper = styled(Link)`
   text-align: center;
   text-decoration: none;
   gap: 10px;
+  color: inherit;
 
   @media screen and (max-width: 768px) {
     height: 100%;

--- a/frontend/src/components/common/Pagination/index.tsx
+++ b/frontend/src/components/common/Pagination/index.tsx
@@ -89,7 +89,7 @@ const ArrowButton = styled.button`
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
-  color: white;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
   box-shadow: none;
   border: none;
 
@@ -117,17 +117,24 @@ const PageNumber = styled.button<PageNumberProps>`
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: ${(props) => (props.$active ? 'black' : 'white')};
+  color: ${(props) => {
+    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : '#333333';
+    return 'black';
+  }};
   cursor: pointer;
 
   ${(props) =>
     props.$active &&
     `
     background: #c8c8c8;
-    border: 1px solid #000;
+    border: 1px solid #a8a8a8;
   `}
 
   &:hover {
     background: ${(props) => (props.$active ? '#c8c8c8' : 'grey')};
+    color: ${(props) => {
+      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'inherit' : '#ffffff';
+      return 'black';
+    }};
   }
 `;

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -212,8 +212,9 @@ const SearchDropDownBox = styled.ul`
 
 const SearchDropDownItem = styled.li`
   padding: 12px 16px;
-
+  border-radius: 0 0 6px 6px;
   &.selected {
     background-color: #686868;
+    background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#686868' : '#d5ecec')};
   }
 `;

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -155,7 +155,7 @@ const SearchBarContainer = styled.div`
 const SearchInputWrapper = styled.div<{ $isOpen: boolean }>`
   display: flex;
   align-items: center;
-  background: #414141;
+  background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#414141' : '#ffffff')};
   padding: 12px 16px;
   border: 1.5px solid #a5a5a5;
   border-bottom: ${({ $isOpen }) => ($isOpen ? 'none' : null)};
@@ -166,7 +166,7 @@ const SearchInputWrapper = styled.div<{ $isOpen: boolean }>`
 const SearchInput = styled.input`
   font-size: 16px;
   flex: 1;
-  color: #ffffff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
   background: transparent;
   border: none;
   margin-right: 8px;
@@ -195,13 +195,13 @@ const SearchDropDownBox = styled.ul`
   position: absolute;
   width: 960px;
   padding: 8px 0px;
-  background-color: #414141;
+  background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#414141' : '#ffffff')};
   border: 1.5px solid #a5a5a5;
   border-top: none;
   border-radius: 0 0 16px 16px;
   box-shadow: 0 10px 10px rgb(0, 0, 0, 0.3);
   list-style-type: none;
-  color: #ffffff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
   box-sizing: border-box;
   z-index: 10;
 

--- a/frontend/src/components/common/layouts/Error.tsx
+++ b/frontend/src/components/common/layouts/Error.tsx
@@ -86,7 +86,7 @@ export default function ErrorComponent({ error, resetErrorBoundary }: FallbackPr
     <Wrapper>
       <TextWrapper>
         <LogoImage src={Logo} alt="인플레이스 로고" />
-        <Paragraph size="xl" weight="bold" variant="white">
+        <Paragraph size="xl" weight="bold">
           {message.title}
         </Paragraph>
         <Paragraph size="m" weight="normal" variant="#bdbdbd">

--- a/frontend/src/components/common/layouts/Error.tsx
+++ b/frontend/src/components/common/layouts/Error.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { AxiosError } from 'axios';
 import Logo from '@/assets/images/Logo.svg';
 import Button from '../Button';
 import { Paragraph } from '../typography/Paragraph';
+import { ThemeContext } from '@/provider/Themes';
 
 type FallbackProps = {
   error?: unknown | AxiosError | Error;
@@ -14,6 +15,8 @@ export default function ErrorComponent({ error, resetErrorBoundary }: FallbackPr
   const location = useLocation();
   const navigate = useNavigate();
   const errorLocation = useRef(location.pathname);
+  const { theme } = useContext(ThemeContext);
+  const buttonVariant = theme === 'dark' ? 'outline' : 'blackOutline';
 
   const handleRetry = () => {
     const isRetriableError =
@@ -93,7 +96,7 @@ export default function ErrorComponent({ error, resetErrorBoundary }: FallbackPr
           {message.description}
         </Paragraph>
       </TextWrapper>
-      <StyledButton aria-label="retry-btn" variant="outline" size="large" onClick={handleRetry}>
+      <StyledButton aria-label="retry-btn" variant={buttonVariant} size="large" onClick={handleRetry}>
         {error instanceof AxiosError && error.response?.status !== 401 && error.response?.status !== 403
           ? '다시 시도하기'
           : '홈으로 가기'}

--- a/frontend/src/components/common/layouts/Footer.tsx
+++ b/frontend/src/components/common/layouts/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
 }
 
 const FooterContainer = styled.footer`
-  background: #2f2f2f;
+  background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#2f2f2f' : '#ceebeb')};
   width: 100%;
   height: 160px;
   padding: 30px;

--- a/frontend/src/components/common/layouts/Footer.tsx
+++ b/frontend/src/components/common/layouts/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
 }
 
 const FooterContainer = styled.footer`
-  background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#2f2f2f' : '#ceebeb')};
+  background: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#2f2f2f' : '#e0f6f6')};
   width: 100%;
   height: 160px;
   padding: 30px;

--- a/frontend/src/components/common/layouts/Header.tsx
+++ b/frontend/src/components/common/layouts/Header.tsx
@@ -65,9 +65,6 @@ export default function Header() {
           </Text>
         </LogoContainer>
       </LogoLink>
-      <ThemeToggle onClick={toggleTheme} aria-label={isDarkMode ? '라이트 모드로 전환' : '다크 모드로 전환'}>
-        {isDarkMode ? <FiSun size={20} color="white" /> : <FiMoon size={20} color="white" />}
-      </ThemeToggle>
       <DesktopNav>
         {isAuthenticated ? (
           <>
@@ -102,6 +99,9 @@ export default function Header() {
                 로그아웃
               </Text>
             </LoginButton>
+            <ThemeButton aria-label="테마 변경 버튼" onClick={toggleTheme}>
+              {isDarkMode ? <FiSun size={20} color="white" /> : <FiMoon size={20} color="black" />}
+            </ThemeButton>
           </>
         ) : (
           <>
@@ -135,6 +135,9 @@ export default function Header() {
                 </LoginButton>
               )}
             </LoginModal>
+            <ThemeButton aria-label="테마 변경 버튼" onClick={toggleTheme}>
+              {isDarkMode ? <FiSun size={20} color="white" /> : <FiMoon size={20} color="black" />}
+            </ThemeButton>
           </>
         )}
       </DesktopNav>
@@ -148,6 +151,11 @@ export default function Header() {
         <MenuContainer variants={itemVariants}>
           {isAuthenticated ? (
             <>
+              <MobileNavItem to="" onClick={toggleTheme}>
+                <Text size="xs" weight="normal">
+                  {isDarkMode ? '라이트 모드' : '다크 모드'}
+                </Text>
+              </MobileNavItem>
               {location.pathname === '/' && (
                 <MobileNavItem
                   to="https://docs.google.com/forms/d/e/1FAIpQLSeBJcQg0gcVv2au5oFZ1aCLF9O_qbEiJCvnLEd0d1SSLLpDUA/viewform?pli=1"
@@ -188,6 +196,11 @@ export default function Header() {
             </>
           ) : (
             <>
+              <MobileNavItem to="" onClick={toggleTheme}>
+                <Text size="xs" weight="normal">
+                  {isDarkMode ? '라이트 모드' : '다크 모드'}
+                </Text>
+              </MobileNavItem>
               {location.pathname === '/' && (
                 <MobileNavItem
                   to="https://docs.google.com/forms/d/e/1FAIpQLSeBJcQg0gcVv2au5oFZ1aCLF9O_qbEiJCvnLEd0d1SSLLpDUA/viewform?pli=1"
@@ -340,7 +353,7 @@ const MenuContainer = styled(motion.div)`
   }
 `;
 
-const ThemeToggle = styled.button`
+const ThemeButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;

--- a/frontend/src/components/common/layouts/Header.tsx
+++ b/frontend/src/components/common/layouts/Header.tsx
@@ -55,7 +55,7 @@ export default function Header() {
   return (
     <HeaderContainer ref={headerRef}>
       <MobileMenuButton aria-label="side_bar" onClick={() => setIsMenuOpen(!isMenuOpen)}>
-        <RiMenuLine size={24} color="white" />
+        <RiMenuLine size={24} color={isDarkMode ? 'white' : 'grey'} />
       </MobileMenuButton>
       <LogoLink to="/">
         <LogoContainer>
@@ -284,7 +284,8 @@ const MobileNav = styled(motion.nav)<{ $isOpen: boolean }>`
     left: 0;
     width: 100%;
     flex-direction: column;
-    background-color: rgba(41, 41, 41, 0.9);
+    background-color: ${({ theme }) =>
+      theme.backgroundColor === '#292929' ? 'rgba(41, 41, 41, 0.9)' : 'rgba(236, 251, 251, 0.9)'};
     padding: 20px 0;
     gap: 20px;
     z-index: 10;
@@ -302,6 +303,7 @@ const NavItem = styled(Link)`
 const MobileNavItem = styled(Link)`
   text-decoration: none;
   cursor: pointer;
+  color: inherit;
 `;
 
 const LoginButton = styled.div`

--- a/frontend/src/components/common/layouts/Header.tsx
+++ b/frontend/src/components/common/layouts/Header.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { RiMenuLine } from 'react-icons/ri';
+import { FiSun, FiMoon } from 'react-icons/fi';
 import { motion, Variants } from 'framer-motion';
 import LoginModal from '@/components/common/modals/LoginModal';
 import { Text } from '@/components/common/typography/Text';
 import Logo from '@/assets/images/Logo.svg';
 import useAuth from '@/hooks/useAuth';
+import useTheme from '@/hooks/useTheme';
 
 const navVariants: Variants = {
   open: {
@@ -36,6 +38,8 @@ export default function Header() {
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
+  const isDarkMode = theme === 'dark';
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -61,6 +65,9 @@ export default function Header() {
           </Text>
         </LogoContainer>
       </LogoLink>
+      <ThemeToggle onClick={toggleTheme} aria-label={isDarkMode ? '라이트 모드로 전환' : '다크 모드로 전환'}>
+        {isDarkMode ? <FiSun size={20} color="white" /> : <FiMoon size={20} color="white" />}
+      </ThemeToggle>
       <DesktopNav>
         {isAuthenticated ? (
           <>
@@ -70,28 +77,28 @@ export default function Header() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   설문조사
                 </Text>
               </NavItem>
             )}
             <NavItem to="/map">
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 지도
               </Text>
             </NavItem>
             <NavItem to="/influencer">
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 인플루언서
               </Text>
             </NavItem>
             <NavItem to="/my">
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 마이페이지
               </Text>
             </NavItem>
             <LoginButton onClick={handleLogout}>
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 로그아웃
               </Text>
             </LoginButton>
@@ -104,25 +111,25 @@ export default function Header() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   설문조사
                 </Text>
               </NavItem>
             )}
             <NavItem to="/map">
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 지도
               </Text>
             </NavItem>
             <NavItem to="/influencer">
-              <Text size="xs" variant="white" weight="normal">
+              <Text size="xs" weight="normal">
                 인플루언서
               </Text>
             </NavItem>
             <LoginModal currentPath={location.pathname}>
               {(openModal: () => void) => (
                 <LoginButton onClick={openModal}>
-                  <Text size="xs" variant="white" weight="normal">
+                  <Text size="xs" weight="normal">
                     로그인
                   </Text>
                 </LoginButton>
@@ -148,23 +155,23 @@ export default function Header() {
                   rel="noopener noreferrer"
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  <Text size="xs" variant="white" weight="normal">
+                  <Text size="xs" weight="normal">
                     설문조사
                   </Text>
                 </MobileNavItem>
               )}
               <MobileNavItem to="/map" onClick={() => setIsMenuOpen(false)}>
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   지도
                 </Text>
               </MobileNavItem>
               <MobileNavItem to="/influencer" onClick={() => setIsMenuOpen(false)}>
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   인플루언서
                 </Text>
               </MobileNavItem>
               <MobileNavItem to="/my" onClick={() => setIsMenuOpen(false)}>
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   마이페이지
                 </Text>
               </MobileNavItem>
@@ -174,7 +181,7 @@ export default function Header() {
                   setIsMenuOpen(false);
                 }}
               >
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   로그아웃
                 </Text>
               </MobileLoginButton>
@@ -188,18 +195,18 @@ export default function Header() {
                   rel="noopener noreferrer"
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  <Text size="xs" variant="white" weight="normal">
+                  <Text size="xs" weight="normal">
                     설문조사
                   </Text>
                 </MobileNavItem>
               )}
               <MobileNavItem to="/map" onClick={() => setIsMenuOpen(false)}>
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   지도
                 </Text>
               </MobileNavItem>
               <MobileNavItem to="/influencer" onClick={() => setIsMenuOpen(false)}>
-                <Text size="xs" variant="white" weight="normal">
+                <Text size="xs" weight="normal">
                   인플루언서
                 </Text>
               </MobileNavItem>
@@ -211,7 +218,7 @@ export default function Header() {
                       setIsMenuOpen(false);
                     }}
                   >
-                    <Text size="xs" variant="white" weight="normal">
+                    <Text size="xs" weight="normal">
                       로그인
                     </Text>
                   </MobileLoginButton>
@@ -289,6 +296,7 @@ const NavItem = styled(Link)`
   margin-left: 20px;
   text-decoration: none;
   cursor: pointer;
+  color: inherit;
 `;
 
 const MobileNavItem = styled(Link)`
@@ -298,12 +306,10 @@ const MobileNavItem = styled(Link)`
 
 const LoginButton = styled.div`
   margin-left: 20px;
-  color: white;
   cursor: pointer;
 `;
 
 const MobileLoginButton = styled.div`
-  color: white;
   cursor: pointer;
 `;
 
@@ -329,5 +335,21 @@ const MenuContainer = styled(motion.div)`
     gap: 20px;
     align-items: center;
     width: 100%;
+  }
+`;
+
+const ThemeToggle = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 20px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+
+  &:hover {
+    transform: rotate(30deg);
   }
 `;

--- a/frontend/src/components/common/layouts/NoItem.tsx
+++ b/frontend/src/components/common/layouts/NoItem.tsx
@@ -14,7 +14,7 @@ function NoItem({ message = '데이터가 없습니다!', height, logo = true, a
     <MessageContainer height={height}>
       <TextWrapper alignItems={alignItems}>
         {logo && <LogoImage src={Logo} alt="인플레이스 로고" />}
-        <Paragraph size="xs" weight="normal" variant="white">
+        <Paragraph size="xs" weight="normal">
           {message}
         </Paragraph>
       </TextWrapper>

--- a/frontend/src/components/common/modals/LoginModal.tsx
+++ b/frontend/src/components/common/modals/LoginModal.tsx
@@ -63,7 +63,7 @@ export default function LoginModal({
               <TitleWrapper>
                 <IconBackground>
                   <LogoImage src={Logo} alt="인플레이스 로고" />
-                  <Paragraph size="xl" weight="bold">
+                  <Paragraph size="xl" weight="bold" variant="black">
                     인플레이스
                   </Paragraph>
                 </IconBackground>

--- a/frontend/src/global.ts
+++ b/frontend/src/global.ts
@@ -18,7 +18,7 @@ const GlobalStyle = createGlobalStyle`
 	}
 
 	html {
-		background-color: #292929;
+		background-color: ${(props) => props.theme.backgroundColor};
 	}
     html, body, div, span, applet, object, iframe,
     h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -47,6 +47,7 @@ footer, header, hgroup, menu, nav, section {
 body {
 	line-height: 1;
 	font-family: 'Noto Sans', sans-serif;
+	color: ${(props) => props.theme.textColor} !important;
 }
 ol, ul {
 	list-style: none;

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from '@/provider/Themes';
+
+export default function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within an ThemeProvider');
+  }
+  return context;
+}

--- a/frontend/src/mocks/detailHandlers.ts
+++ b/frontend/src/mocks/detailHandlers.ts
@@ -136,10 +136,22 @@ export const detailHandlers = [
         videos: [
           {
             influencerName: '성시경',
-            videoUrl: 'https://www.youtube.com/watch?v=nCEtQ7dP8zY',
+            videoUrl: 'https://www.youtube.com/watch?v=ZC5klhd08ME',
           },
           {
-            influencerName: '',
+            influencerName: '광마니',
+            videoUrl: 'https://www.youtube.com/watch?v=cgAPp2SRDiE',
+          },
+          {
+            influencerName: '쯔양',
+            videoUrl: 'https://www.youtube.com/watch?v=B_gGpdUVe8o',
+          },
+          {
+            influencerName: '떡볶퀸',
+            videoUrl: 'https://www.youtube.com/watch?v=YdrW34lver4',
+          },
+          {
+            influencerName: '기본',
             videoUrl: BasicImage,
           },
         ],

--- a/frontend/src/pages/Choice/index.tsx
+++ b/frontend/src/pages/Choice/index.tsx
@@ -105,7 +105,7 @@ export default function ChoicePage() {
   return (
     <PageContainer>
       <Title>
-        <Text size="l" weight="bold" variant="white">
+        <Text size="l" weight="bold">
           관심 있는{' '}
           <Text size="ll" weight="bold" variant="mint">
             인플루언서

--- a/frontend/src/pages/Detail/index.tsx
+++ b/frontend/src/pages/Detail/index.tsx
@@ -331,7 +331,10 @@ const GradientOverlay = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.9) 100%);
+  background: ${({ theme }) =>
+    theme.backgroundColor === '#292929'
+      ? 'linear-gradient(to bottom, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.9) 100%)'
+      : 'linear-gradient(to bottom, rgba(0, 0, 0, 0) 25%, rgba(30, 30, 30, 0.8) 100%)'};
   z-index: 0;
   pointer-events: none;
 `;

--- a/frontend/src/pages/Detail/index.tsx
+++ b/frontend/src/pages/Detail/index.tsx
@@ -281,8 +281,9 @@ const Tap = styled.button`
   font-size: 18px;
   font-weight: bold;
   color: #55ebff;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#55ebff' : '#333333')};
   border: none;
-  border-bottom: 3px solid #55ebff;
+  border-bottom: 3px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#55ebff' : '#333333')};
   background: none;
   cursor: pointer;
   transition:
@@ -292,7 +293,7 @@ const Tap = styled.button`
   @media screen and (max-width: 768px) {
     height: 50px;
     font-size: 16px;
-    border-bottom: 2px solid #55ebff;
+    border-bottom: 2px solid ${({ theme }) => (theme.textColor === '#ffffff' ? '#55ebff' : '#333333')};
   }
 `;
 

--- a/frontend/src/pages/Influencer/index.tsx
+++ b/frontend/src/pages/Influencer/index.tsx
@@ -49,7 +49,7 @@ export default function InfluencerPage() {
   return (
     <PageContainer>
       <Title>
-        <Text size="l" weight="bold" variant="white">
+        <Text size="l" weight="bold">
           인플루언서
         </Text>
       </Title>

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -202,9 +202,16 @@ const Tap = styled.button<{ $active: boolean }>`
   height: 60px;
   font-size: 18px;
   font-weight: bold;
-  color: ${({ $active }) => ($active ? '#55ebff' : 'white')};
+  color: ${(props) => {
+    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : 'black';
+    return '#55ebff';
+  }};
   border: none;
-  border-bottom: 3px solid ${({ $active }) => ($active ? '#55ebff' : 'white')};
+  border-bottom: 3px solid
+    ${(props) => {
+      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : 'black';
+      return '#55ebff';
+    }};
   background: none;
   cursor: pointer;
   transition:
@@ -214,7 +221,7 @@ const Tap = styled.button<{ $active: boolean }>`
   @media screen and (max-width: 768px) {
     height: 50px;
     font-size: 16px;
-    border-bottom: 2px solid ${({ $active }) => ($active ? '#55ebff' : 'white')};
+    border-bottom: 2px solid;
   }
 `;
 const TapContainer = styled.div`

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -203,13 +203,13 @@ const Tap = styled.button<{ $active: boolean }>`
   font-size: 18px;
   font-weight: bold;
   color: ${(props) => {
-    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : 'black';
+    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : '#8c8c8c';
     return '#55ebff';
   }};
   border: none;
   border-bottom: 3px solid
     ${(props) => {
-      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : 'black';
+      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : '#8c8c8c';
       return '#55ebff';
     }};
   background: none;

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -75,13 +75,13 @@ export default function InfluencerInfoPage() {
           <FallbackImage src={influencerInfoData.influencerImgUrl} alt={influencerInfoData.influencerName} />
         </Image>
         <TextInfo>
-          <Text size="xl" weight="bold" variant="white">
+          <Text size="xl" weight="bold">
             {influencerInfoData.influencerName}
           </Text>
-          <Text size="s" weight="normal" variant="white">
+          <Text size="s" weight="normal">
             좋아요 수 {influencerInfoData.follower}명 • 쿨 플레이스 {influencerInfoData.placeCount}곳
           </Text>
-          <Text size="xs" weight="normal" variant="white">
+          <Text size="xs" weight="normal">
             {influencerInfoData.influencerJob}
           </Text>
         </TextInfo>
@@ -93,7 +93,7 @@ export default function InfluencerInfoPage() {
           {isLike ? (
             <PiHeartFill color="#fe7373" size={32} data-testid="PiHeartFill" />
           ) : (
-            <PiHeartLight color="white" size={32} data-testid="PiHeartLight" />
+            <PiHeartLight size={32} data-testid="PiHeartLight" />
           )}
         </LikeIcon>
       </InfluencerInfoSection>

--- a/frontend/src/pages/Map/index.tsx
+++ b/frontend/src/pages/Map/index.tsx
@@ -304,7 +304,7 @@ const MobilePlaceSection = styled.div<{ $translateY: number; $isExpanded: boolea
     width: 100%;
     transform: translateY(${(props) => props.$translateY}px);
     height: 80vh;
-    background-color: #3c3c3c;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#3c3c3c' : '#fafafa')};
     z-index: 90;
     border-top-left-radius: 16px;
     border-top-right-radius: 16px;

--- a/frontend/src/pages/Map/index.tsx
+++ b/frontend/src/pages/Map/index.tsx
@@ -170,7 +170,7 @@ export default function MapPage() {
   return (
     <PageContainer>
       <Wrapper>
-        <Text size="l" weight="bold" variant="white">
+        <Text size="l" weight="bold">
           지도
         </Text>
         <DropdownContainer>

--- a/frontend/src/pages/My/index.tsx
+++ b/frontend/src/pages/My/index.tsx
@@ -71,7 +71,7 @@ export default function MyPage() {
       <TitleWrapper>
         {isVisible ? (
           <NickNameWrapper>
-            <Text size="l" weight="bold" variant="white">
+            <Text size="l" weight="bold">
               <Text size="xl" weight="bold" variant="mint">
                 {userNickname?.nickname}
               </Text>
@@ -89,7 +89,7 @@ export default function MyPage() {
             </CustomButton>
           </Form>
         )}
-        <Paragraph size="m" weight="bold" variant="white">
+        <Paragraph size="m" weight="bold">
           인플레이스를 이용해주셔서 감사합니다.
         </Paragraph>
       </TitleWrapper>

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -1,11 +1,15 @@
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '@/components/common/Button';
 import Logo from '@/assets/images/Logo.svg';
 import { Paragraph } from '@/components/common/typography/Paragraph';
+import { ThemeContext } from '@/provider/Themes';
 
 export default function NotFound() {
   const navigate = useNavigate();
+  const { theme } = useContext(ThemeContext);
+  const buttonVariant = theme === 'dark' ? 'outline' : 'blackOutline';
   const handleHome = () => {
     navigate('/');
   };
@@ -20,7 +24,7 @@ export default function NotFound() {
           요청한 페이지가 존재하지 않거나 삭제되었어요.
         </Paragraph>
       </TextWrapper>
-      <StyledButton aria-label="home-btn" variant="outline" onClick={handleHome}>
+      <StyledButton aria-label="home-btn" variant={buttonVariant} onClick={handleHome}>
         홈으로 이동하기
       </StyledButton>
     </Wrapper>

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -13,10 +13,10 @@ export default function NotFound() {
     <Wrapper>
       <TextWrapper>
         <LogoImage src={Logo} alt="인플레이스 로고" />
-        <Paragraph size="xl" weight="bold" variant="white">
+        <Paragraph size="xl" weight="bold">
           페이지를 찾을 수 없어요 🥲
         </Paragraph>
-        <Paragraph size="m" weight="normal" variant="#bdbdbd">
+        <Paragraph size="m" weight="normal">
           요청한 페이지가 존재하지 않거나 삭제되었어요.
         </Paragraph>
       </TextWrapper>

--- a/frontend/src/pages/Search/index.tsx
+++ b/frontend/src/pages/Search/index.tsx
@@ -60,6 +60,7 @@ const Wrapper = styled.div`
 const SplitLine = styled.div`
   width: 100%;
   border-bottom: 1px solid #595959;
+  border-bottom: 1px solid ${({ theme }) => (theme.backgroundColor === '#292929' ? '#595959' : '#bababa')};
   @media screen and (max-width: 768px) {
     border: none;
   }

--- a/frontend/src/pages/Search/index.tsx
+++ b/frontend/src/pages/Search/index.tsx
@@ -16,7 +16,7 @@ export default function SearchPage() {
     <Wrapper>
       <SearchBar placeholder="인플루언서, 장소를 검색해주세요!" />
       <Title>
-        <Paragraph weight="normal" size="m" variant="white">
+        <Paragraph weight="normal" size="m">
           <Text weight="bold" size="m" variant="mint">
             {`${query} `}
           </Text>

--- a/frontend/src/provider/Themes/index.tsx
+++ b/frontend/src/provider/Themes/index.tsx
@@ -7,7 +7,7 @@ const darkMode = {
 };
 
 const lightMode = {
-  backgroundColor: '#f5f5f5d3',
+  backgroundColor: '#ecfbfb',
   textColor: '#333333',
 };
 

--- a/frontend/src/provider/Themes/index.tsx
+++ b/frontend/src/provider/Themes/index.tsx
@@ -1,0 +1,49 @@
+import { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components';
+
+const darkMode = {
+  backgroundColor: '#292929',
+  textColor: '#ffffff',
+};
+
+const lightMode = {
+  backgroundColor: '#f5f5f5d3',
+  textColor: '#333333',
+};
+
+type ThemeContextType = {
+  theme: string;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export default function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState(() => {
+    const settingTheme = localStorage.getItem('theme');
+    return settingTheme || 'dark';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('theme', theme);
+    console.log('바뀐 theme:', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+  const themeMode = theme === 'dark' ? darkMode : lightMode;
+
+  return (
+    <ThemeContext.Provider value={useMemo(() => ({ theme, toggleTheme }), [theme])}>
+      <StyledThemeProvider theme={themeMode}>{children}</StyledThemeProvider>
+    </ThemeContext.Provider>
+  );
+}


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 테마 모드를 관리하는 `themeProvider` 추가
- [x] `global.ts`에 `color` 추가 및 하드코딩 된 값 수정
- [x] themeProvider로 전달된 테마에 따라 공통 컴포넌트 스타일 조건부 적용
- [x] 페이지별로 컴포넌트 스타일 조건부 적용
- [x] 헤더에 테마 변경 아이콘 추가
- [x] 색감 관련 1차 피드백 반영
---

### ✨ 참고 사항
- `themeProvider` 안에 `GlobalStyle`이 있는 만큼, 스타일 코드에서만 조건부로 수정이 필요한 값은 `useTheme`으로 굳이 안 가져오고, `backgroundColor`, `textColor` 값을 활용해서 변경했습니다.
- 버튼 variant 중 `blackOutline`는 라이트 모드 추가 전까지 어느 곳에서도 사용이 안 되었기 때문에, 호버할 때의 `backgroundColor`를 현재 라이트 모드와 잘 어울리도록 색상을 `Button` 컴포넌트에서 직접 수정했습니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close
