### PR TITLE
[INPLACE-171] 인플루언서 페이지 영상 정렬

### DIFF
--- a/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
+++ b/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
@@ -1,6 +1,10 @@
 package team7.inplace.video.persistence;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,14 +14,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import team7.inplace.video.persistence.dto.VideoQueryResult;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -168,14 +168,14 @@ public class VideoReadRepositoryTest {
     }
 
     @Test
-    @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회")
+    @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 기본(날짜 순) 정렬")
     void findVideo_InfluencerId() {
         // given
         Pageable pageable = PageRequest.of(0, 5);
 
         final int expectedTotalContent = 4;
         final int expectedContentSize = 4;
-        final List<Long> expectedVideoIds = List.of(1L, 2L, 3L ,4L);
+        final List<Long> expectedVideoIds = List.of(4L, 3L, 2L, 1L);
 
         // when
         Page<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findSimpleVideosWithOneInfluencerId(
@@ -186,5 +186,47 @@ public class VideoReadRepositoryTest {
         assertThat(videos.getContent().size()).isEqualTo(expectedContentSize);
         assertThat(videos.getContent().stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
                 .isEqualTo(expectedVideoIds);
+    }
+
+    @Test
+    @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 인기순(조회수 증가량) 정렬")
+    void findVideo_InfluencerId_popularity() {
+        // given
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("popularity"));
+
+        final int expectedTotalContent = 4;
+        final int expectedContentSize = 4;
+        final List<Long> expectedVideoIds = List.of(4L, 3L, 2L, 1L);
+
+        // when
+        Page<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findSimpleVideosWithOneInfluencerId(
+            1L, pageable);
+
+        // then
+        assertThat(videos.getTotalElements()).isEqualTo(expectedTotalContent);
+        assertThat(videos.getContent().size()).isEqualTo(expectedContentSize);
+        assertThat(videos.getContent().stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
+            .isEqualTo(expectedVideoIds);
+    }
+
+    @Test
+    @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 장소 좋아요순 정렬")
+    void findVideo_InfluencerId_likes() {
+        // given
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("likes"));
+
+        final int expectedTotalContent = 4;
+        final int expectedContentSize = 4;
+        final List<Long> expectedVideoIds = List.of(3L, 2L, 1L, 4L);
+
+        // when
+        Page<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findSimpleVideosWithOneInfluencerId(
+            1L, pageable);
+
+        // then
+        assertThat(videos.getTotalElements()).isEqualTo(expectedTotalContent);
+        assertThat(videos.getContent().size()).isEqualTo(expectedContentSize);
+        assertThat(videos.getContent().stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
+            .isEqualTo(expectedVideoIds);
     }
 }

--- a/backend/src/test/resources/sql/test-video.sql
+++ b/backend/src/test/resources/sql/test-video.sql
@@ -55,7 +55,11 @@ VALUES (1, 1, 1, 'Video1', 1, '2025-02-06 12:00:01.000000'),
        (25, 5, null, 'Video25', 20, '2025-02-06 12:24:01.000000');
 
 INSERT INTO users (id, nickname, password, username, role)
-VALUES ( 1, 'Test', 'password@', 'TestUser', 'USER' );
+VALUES ( 1, 'Test', 'password@', 'TestUser1', 'USER' ),
+       ( 2, 'Test', 'password@', 'TestUser2', 'USER' ),
+       ( 3, 'Test', 'password@', 'TestUser3', 'USER' ),
+       ( 4, 'Test', 'password@', 'TestUser4', 'USER' ),
+       ( 5, 'Test', 'password@', 'TestUser5', 'USER' );
 
 INSERT INTO liked_influencers (id, influencer_id, user_id, is_liked)
 VALUES (1, 1, 1, true),
@@ -63,3 +67,15 @@ VALUES (1, 1, 1, true),
        (3, 3, 1, false),
        (4, 4, 1, false),
        (5, 5, 1, true);
+
+INSERT INTO liked_places (id, place_id, user_id, is_liked)
+VALUES (1, 1, 1, true),
+       (2, 1, 2, false),
+       (3, 1, 3, false),
+       (4, 2, 1, true),
+       (5, 2, 2, true),
+       (6, 3, 1, true),
+       (7, 3, 2, true),
+       (8, 3, 3, true),
+       (9, 3, 4, true),
+       (10, 3, 5, true);


### PR DESCRIPTION
### ✨ 작업 내용
- 인플루언서 페이지 영상 정렬 조건 추가(popularity, likes, publishTime)
---

### ✨ 참고 사항
- popularity: 해당 인플루언서의 비디오의 조회수 증가량 순
- likes: 해당 인플루언서의 비디오의 연결된 장소의 좋아요 순
- publishTime: 해당 인플루언서의 비디오의 시간 순 
- 기본은 최신 순으로 해뒀습니다

---

### ⏰ 현재 버그

---

### ✏ Git Close
