### PR TITLE
[INPLACE-183] 인플루언서 비디오 sort 버튼 추가

### DIFF
--- a/frontend/src/api/hooks/useGetInfluencerVideo.ts
+++ b/frontend/src/api/hooks/useGetInfluencerVideo.ts
@@ -3,22 +3,23 @@ import { fetchInstance } from '../instance';
 import { PageableData, SpotData } from '@/types';
 
 export const getInfluencerVideoPath = (id: string) => `/influencers/${id}/videos`;
-export const getInfluencerVideo = async (id: string, page: number, size: number) => {
+export const getInfluencerVideo = async (id: string, page: number, size: number, sort: string) => {
   const params = new URLSearchParams({
     page: page.toString(),
     size: size.toString(),
+    sort,
   });
   const response = await fetchInstance.get<PageableData<SpotData>>(`${getInfluencerVideoPath(id)}?${params}`);
   return response.data;
 };
-export const useGetInfluencerVideo = (id: string, size: number) => {
+export const useGetInfluencerVideo = (id: string, size: number, sort: string) => {
   return useSuspenseInfiniteQuery({
-    queryKey: ['influencerVideo', id, size],
-    queryFn: ({ pageParam = 0 }) => getInfluencerVideo(id, pageParam, size),
+    queryKey: ['influencerVideo', id, size, sort],
+    queryFn: ({ pageParam = 0 }) => getInfluencerVideo(id, pageParam, size, sort),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       return lastPage.last ? undefined : lastPage.number + 1;
     },
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
   });
 };

--- a/frontend/src/api/hooks/useGetInfluencerVideo.ts
+++ b/frontend/src/api/hooks/useGetInfluencerVideo.ts
@@ -1,4 +1,4 @@
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { fetchInstance } from '../instance';
 import { PageableData, SpotData } from '@/types';
 
@@ -12,14 +12,9 @@ export const getInfluencerVideo = async (id: string, page: number, size: number,
   const response = await fetchInstance.get<PageableData<SpotData>>(`${getInfluencerVideoPath(id)}?${params}`);
   return response.data;
 };
-export const useGetInfluencerVideo = (id: string, size: number, sort: string) => {
-  return useSuspenseInfiniteQuery({
-    queryKey: ['influencerVideo', id, size, sort],
-    queryFn: ({ pageParam = 0 }) => getInfluencerVideo(id, pageParam, size, sort),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => {
-      return lastPage.last ? undefined : lastPage.number + 1;
-    },
-    staleTime: 0,
+export const useGetInfluencerVideo = (id: string, page: number, size: number, sort: string) => {
+  return useQuery({
+    queryKey: ['influencerVideo', id, page, size, sort],
+    queryFn: () => getInfluencerVideo(id, page, size, sort),
   });
 };

--- a/frontend/src/api/hooks/useGetMain.ts
+++ b/frontend/src/api/hooks/useGetMain.ts
@@ -33,7 +33,6 @@ export const useGetMain = () => {
         queryKey: ['influencers'],
         queryFn: getInfluencer,
         staleTime: 1000 * 60 * 5,
-        refetchOnMount: 'always',
       },
     ],
   });

--- a/frontend/src/components/InfluencerInfo/InfluencerVideoTap/index.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerVideoTap/index.tsx
@@ -1,66 +1,103 @@
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { SpotData } from '@/types';
 import NoItem from '@/components/common/layouts/NoItem';
 import SpotItem from '@/components/Main/SpotSection/SpotItem';
 import Loading from '@/components/common/layouts/Loading';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import Pagination from '@/components/common/Pagination';
+import { useGetInfluencerVideo } from '@/api/hooks/useGetInfluencerVideo';
 
 type Props = {
-  items: SpotData[];
-  fetchNextPage: () => void;
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
+  influencerId: string;
+  sortOption: string;
 };
-export default function InfluencerVideoTap({ items, fetchNextPage, hasNextPage, isFetchingNextPage }: Props) {
-  const loadMoreRef = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
+
+export default function InfluencerVideoTap({ influencerId, sortOption }: Props) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 6;
+
+  const { data: videoData, isLoading } = useGetInfluencerVideo(influencerId, currentPage - 1, PAGE_SIZE, sortOption);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [sortOption]);
+
+  const handlePageChange = (pageNum: number) => {
+    setCurrentPage(pageNum);
+  };
+
+  if (isLoading) {
+    return (
+      <Container>
+        <LoadingWrapper>
+          <Loading size={30} />
+        </LoadingWrapper>
+      </Container>
+    );
+  }
 
   return (
     <Container>
-      {items.length === 0 ? (
+      {!videoData || videoData.content.length === 0 ? (
         <NoItem message="그곳 정보가 없어요!" alignItems="center" />
       ) : (
-        <GridContainer>
-          {items.map((item, index) => {
-            const column = (index % 2) + 1;
-            return (
-              <GridItem key={item.videoId} $column={column}>
-                <SpotItem
-                  key={item.videoId}
-                  videoId={item.videoId}
-                  videoAlias={item.videoAlias}
-                  videoUrl={item.videoUrl}
-                  place={item.place}
-                  isInfluencer
-                />
-              </GridItem>
-            );
-          })}
-          {(hasNextPage || isFetchingNextPage) && (
-            <LoadMoreTrigger ref={loadMoreRef}>{isFetchingNextPage ? <Loading size={30} /> : null}</LoadMoreTrigger>
-          )}
-        </GridContainer>
+        <>
+          <GridContainer>
+            {videoData.content.map((item, index) => {
+              const column = (index % 2) + 1;
+              return (
+                <GridItem key={item.videoId} $column={column}>
+                  <SpotItem
+                    key={item.videoId}
+                    videoId={item.videoId}
+                    videoAlias={item.videoAlias}
+                    videoUrl={item.videoUrl}
+                    place={item.place}
+                    isInfluencer
+                  />
+                </GridItem>
+              );
+            })}
+          </GridContainer>
+
+          <Pagination
+            currentPage={currentPage}
+            totalPages={videoData.totalPages || 0}
+            totalItems={videoData.totalElements}
+            onPageChange={handlePageChange}
+            itemsPerPage={PAGE_SIZE}
+          />
+        </>
       )}
     </Container>
   );
 }
+
 const GridContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-row-gap: 60px;
+  margin-bottom: 50px;
 
   @media screen and (max-width: 768px) {
     grid-template-columns: repeat(1, 1fr);
     grid-row-gap: 40px;
+    margin-bottom: 40px;
   }
 `;
-const Container = styled.div``;
-const LoadMoreTrigger = styled.div`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const LoadingWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   height: 60px;
   margin-top: 20px;
 `;
+
 const GridItem = styled.div<{ $column: number }>`
   justify-self: ${({ $column }) => ($column === 1 ? 'start' : 'end')};
   @media screen and (max-width: 768px) {

--- a/frontend/src/components/common/Pagination/index.tsx
+++ b/frontend/src/components/common/Pagination/index.tsx
@@ -93,11 +93,6 @@ const ArrowButton = styled.button`
   box-shadow: none;
   border: none;
 
-  &:hover:not(:disabled) {
-    background: #c8c8c8;
-    color: black;
-  }
-
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
@@ -118,7 +113,7 @@ const PageNumber = styled.button<PageNumberProps>`
   border-radius: 4px;
   background: transparent;
   color: ${(props) => {
-    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : '#333333';
+    if (!props.$active) return props.theme.textColor === '#ffffff' ? 'white' : '#979797';
     return 'black';
   }};
   cursor: pointer;
@@ -126,14 +121,18 @@ const PageNumber = styled.button<PageNumberProps>`
   ${(props) =>
     props.$active &&
     `
-    background: #c8c8c8;
-    border: 1px solid #a8a8a8;
+    background: ${props.theme.backgroundColor === '#292929' ? '#c8c8c8' : '#c6e6e6'};
   `}
 
   &:hover {
-    background: ${(props) => (props.$active ? '#c8c8c8' : 'grey')};
+    background: ${(props) => {
+      if (props.theme.backgroundColor === '#292929') {
+        return props.$active ? '#c8c8c8' : 'grey';
+      }
+      return props.$active ? '#c7c8c8' : '#e0f6f6';
+    }};
     color: ${(props) => {
-      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'inherit' : '#ffffff';
+      if (!props.$active) return props.theme.textColor === '#ffffff' ? 'inherit' : '#626262';
       return 'black';
     }};
   }

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -16,20 +16,12 @@ import { useGetInfluencerInfo } from '@/api/hooks/useGetInfluencerInfo';
 import Loading from '@/components/common/layouts/Loading';
 import InfluencerVideoTap from '@/components/InfluencerInfo/InfluencerVideoTap';
 import InfluencerMapTap from '@/components/InfluencerInfo/InfluencerMapTap';
-import { useGetInfluencerVideo } from '@/api/hooks/useGetInfluencerVideo';
 import Button from '@/components/common/Button';
 
 export default function InfluencerInfoPage() {
   const { id } = useParams() as { id: string };
   const { data: influencerInfoData } = useGetInfluencerInfo(id);
   const [sortOption, setSortOption] = useState('publishTime');
-
-  const {
-    data: videos,
-    fetchNextPage: videoFetchNextPage,
-    hasNextPage: videoHasNextPage,
-    isFetchingNextPage: videoIsFetchingNextPage,
-  } = useGetInfluencerVideo(id, 6, sortOption);
 
   const sortLabel: Record<string, string> = {
     publishTime: '최신순',
@@ -147,12 +139,7 @@ export default function InfluencerInfoPage() {
           </SortSection>
         )}
         {activeTab === 'video' ? (
-          <InfluencerVideoTap
-            items={videos.pages.flatMap((page) => page.content)}
-            hasNextPage={videoHasNextPage}
-            fetchNextPage={videoFetchNextPage}
-            isFetchingNextPage={videoIsFetchingNextPage}
-          />
+          <InfluencerVideoTap influencerId={id} sortOption={sortOption} />
         ) : (
           <QueryErrorResetBoundary>
             {({ reset }) => (

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -25,8 +25,8 @@ export default function InfluencerInfoPage() {
 
   const sortLabel: Record<string, string> = {
     publishTime: '최신순',
-    popularity: '조회수 증가량 순',
-    likes: '장소 좋아요 순',
+    popularity: '인기순',
+    likes: '좋아요순',
   };
 
   const influencerId = Number(id);
@@ -130,10 +130,8 @@ export default function InfluencerInfoPage() {
                 <SortItem onClick={() => handleSortChange('publishTime')}>
                   최신순 {sortOption === 'publishTime'}
                 </SortItem>
-                <SortItem onClick={() => handleSortChange('popularity')}>
-                  조회수 증가량 순 {sortOption === 'popularity'}
-                </SortItem>
-                <SortItem onClick={() => handleSortChange('likes')}>장소 좋아요 순 {sortOption === 'likes'}</SortItem>
+                <SortItem onClick={() => handleSortChange('popularity')}>인기순 {sortOption === 'popularity'}</SortItem>
+                <SortItem onClick={() => handleSortChange('likes')}>좋아요순 {sortOption === 'likes'}</SortItem>
               </SortDropdown>
             )}
           </SortSection>
@@ -269,12 +267,12 @@ const SortSection = styled.div`
   position: relative;
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 20px;
-  margin-top: -30px;
+  margin-bottom: 10px;
+  margin-top: -40px;
 
   @media screen and (max-width: 768px) {
-    margin-bottom: 10px;
-    margin-top: -10px;
+    margin-bottom: 6px;
+    margin-top: -14px;
   }
 `;
 
@@ -282,17 +280,20 @@ const StyledButton = styled(Button)`
   justify-content: space-between;
   gap: 8px;
   padding: 6px 10px;
-  width: 130px;
+  width: 90px;
   cursor: pointer;
   font-size: 14px;
   margin-left: auto;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
+
+  background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#292929' : '#ecfbfb')};
 
   &:hover {
-    background-color: #f8f8f8;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#222222' : '#daeeee')};
   }
 
   @media screen and (max-width: 768px) {
-    width: 120px;
+    width: 80px;
     font-size: 12px;
     padding: 4px 8px;
   }
@@ -302,15 +303,15 @@ const SortDropdown = styled.div`
   position: absolute;
   top: 100%;
   z-index: 2;
-  background-color: white;
+  background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#292929' : '#ecfbfb')};
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  width: 130px;
+  width: 90px;
   margin-top: 4px;
-  color: black;
+  color: ${({ theme }) => (theme.textColor === '#ffffff' ? '#ffffff' : '#333333')};
 
   @media screen and (max-width: 768px) {
-    width: 120px;
+    width: 80px;
   }
 `;
 
@@ -322,7 +323,7 @@ const SortItem = styled.div`
   cursor: pointer;
 
   &:hover {
-    background-color: #f8f8f8;
+    background-color: ${({ theme }) => (theme.backgroundColor === '#292929' ? '#222222' : '#daeeee')};
   }
 
   @media screen and (max-width: 768px) {

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -1,4 +1,5 @@
 import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+import { IoIosArrowDown } from 'react-icons/io';
 
 import styled from 'styled-components';
 import { useLocation, useParams } from 'react-router-dom';
@@ -16,16 +17,25 @@ import Loading from '@/components/common/layouts/Loading';
 import InfluencerVideoTap from '@/components/InfluencerInfo/InfluencerVideoTap';
 import InfluencerMapTap from '@/components/InfluencerInfo/InfluencerMapTap';
 import { useGetInfluencerVideo } from '@/api/hooks/useGetInfluencerVideo';
+import Button from '@/components/common/Button';
 
 export default function InfluencerInfoPage() {
   const { id } = useParams() as { id: string };
   const { data: influencerInfoData } = useGetInfluencerInfo(id);
+  const [sortOption, setSortOption] = useState('publishTime');
+
   const {
     data: videos,
     fetchNextPage: videoFetchNextPage,
     hasNextPage: videoHasNextPage,
     isFetchingNextPage: videoIsFetchingNextPage,
-  } = useGetInfluencerVideo(id, 6);
+  } = useGetInfluencerVideo(id, 6, sortOption);
+
+  const sortLabel: Record<string, string> = {
+    publishTime: '최신순',
+    popularity: '조회수 증가량 순',
+    likes: '장소 좋아요 순',
+  };
 
   const influencerId = Number(id);
 
@@ -35,6 +45,7 @@ export default function InfluencerInfoPage() {
   const [activeTab, setActiveTab] = useState<'video' | 'map'>('video');
   const [isLike, setIsLike] = useState(influencerInfoData.likes);
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showSortOptions, setShowSortOptions] = useState(false);
   const queryClient = useQueryClient();
 
   const { mutate: postLike } = usePostInfluencerLike();
@@ -63,6 +74,11 @@ export default function InfluencerInfoPage() {
     },
     [isLike, influencerId, postLike],
   );
+
+  const handleSortChange = (option: string) => {
+    setSortOption(option);
+    setShowSortOptions(false);
+  };
 
   useEffect(() => {
     setIsLike(influencerInfoData.likes);
@@ -106,6 +122,30 @@ export default function InfluencerInfoPage() {
         </Tap>
       </TapContainer>
       <InfoContainer>
+        {activeTab === 'video' && (
+          <SortSection>
+            <StyledButton
+              aria-label="sort_btn"
+              variant="white"
+              size="small"
+              onClick={() => setShowSortOptions(!showSortOptions)}
+            >
+              <span>{sortLabel[sortOption]}</span>
+              <IoIosArrowDown size={16} />
+            </StyledButton>
+            {showSortOptions && (
+              <SortDropdown>
+                <SortItem onClick={() => handleSortChange('publishTime')}>
+                  최신순 {sortOption === 'publishTime'}
+                </SortItem>
+                <SortItem onClick={() => handleSortChange('popularity')}>
+                  조회수 증가량 순 {sortOption === 'popularity'}
+                </SortItem>
+                <SortItem onClick={() => handleSortChange('likes')}>장소 좋아요 순 {sortOption === 'likes'}</SortItem>
+              </SortDropdown>
+            )}
+          </SortSection>
+        )}
         {activeTab === 'video' ? (
           <InfluencerVideoTap
             items={videos.pages.flatMap((page) => page.content)}
@@ -235,5 +275,71 @@ const TapContainer = styled.div`
 const InfoContainer = styled.div`
   @media screen and (max-width: 768px) {
     width: 90%;
+  }
+`;
+
+const SortSection = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+  margin-top: -30px;
+
+  @media screen and (max-width: 768px) {
+    margin-bottom: 10px;
+    margin-top: -10px;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  width: 130px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-left: auto;
+
+  &:hover {
+    background-color: #f8f8f8;
+  }
+
+  @media screen and (max-width: 768px) {
+    width: 120px;
+    font-size: 12px;
+    padding: 4px 8px;
+  }
+`;
+
+const SortDropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  z-index: 2;
+  background-color: white;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 130px;
+  margin-top: 4px;
+  color: black;
+
+  @media screen and (max-width: 768px) {
+    width: 120px;
+  }
+`;
+
+const SortItem = styled.div`
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f8f8f8;
+  }
+
+  @media screen and (max-width: 768px) {
+    font-size: 12px;
+    padding: 8px 10px;
   }
 `;


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 인플루언서 비디오 sort 버튼 추가
- [x] 메인에서 `/influencers` 2번 호출하는 버그 수정
- [x] 인플루언서 전용페이지에서 동영상을 무한스크롤 대신 숫자 컴포넌트 사용하도록 수정
---

### ✨ 참고 사항
- 인플루언서 페이지 영상 정렬하는 옵션 총 3개: sort=에 하나씩 적으면 됨
  1. popularity(조회수 증가량 순)
  2. likes(장소 좋아요 순)
  3. publishTime(최신순, 얘가 디폴트라서 적어도 되고 안적어도됨)

- 무한 스크롤에서 숫자 페이지네이션 적용하기 위해 `useGetInfluencerVideo` 훅도 수정함. 다른 곳에서 사용하는 곳 없는 거까지 확인했어!

---

### ⏰ 현재 버그

---

### ✏ Git Close
