### PR TITLE
[INPLACE-200] 1초가 넘어갈 때 로그 출력하도록 변경

### DIFF
--- a/backend/src/main/java/team7/inplace/security/filter/ApiExecutionMetricsFilter.java
+++ b/backend/src/main/java/team7/inplace/security/filter/ApiExecutionMetricsFilter.java
@@ -3,7 +3,6 @@ package team7.inplace.security.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,10 +52,13 @@ public class ApiExecutionMetricsFilter extends OncePerRequestFilter {
             }
 
             String layersJson = toJson(records);
-            meterRegistry.gauge("api.layer.execution.time",
-                Tags.of("requestId", requestId, "path", path, "layers", layersJson),
-                totalTime
-            );
+            if (totalTime > 1000) {
+                log.warn("API execution time exceeded 1 second: {}", layersJson);
+            }
+//            meterRegistry.gauge("api.layer.execution.time",
+//                Tags.of("requestId", requestId, "path", path, "layers", layersJson),
+//                totalTime
+//            );
             ThreadExecutionContext.clear();
         }
     }


### PR DESCRIPTION
### ✨ 작업 내용

- Prometheus로 메트릭을 출력함으로 인해 메모리 사용량이 늘어났습니다.
- Loki로 바꿀 떄 까지 임시방편으로 log.warn으로 변경했습니다.
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
