### PR TITLE
[INPLACE-211] 비디오 반환 값 수정

### DIFF
--- a/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
@@ -53,7 +53,7 @@ public class VideoFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.SimpleVideo> getMyInfluencerVideos() {
+    public List<VideoQueryResult.DetailedVideo> getMyInfluencerVideos() {
         // User 정보를 쿠키에서 추출
         Long userId = AuthorizationUtil.getUserId();
         // 인플루언서 id를 사용하여 영상을 조회

--- a/backend/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoService.java
@@ -18,6 +18,7 @@ import team7.inplace.video.persistence.RecentVideoRepository;
 import team7.inplace.video.persistence.VideoReadRepository;
 import team7.inplace.video.persistence.VideoRepository;
 import team7.inplace.video.persistence.dto.VideoQueryResult;
+import team7.inplace.video.persistence.dto.VideoQueryResult.DetailedVideo;
 import team7.inplace.video.persistence.dto.VideoQueryResult.SimpleVideo;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
 
@@ -32,7 +33,7 @@ public class VideoService {
 
     //TODO: Facade에서 호출로 변경해야함.
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.SimpleVideo> getVideosBySurround(
+    public List<VideoQueryResult.DetailedVideo> getVideosBySurround(
         VideoSearchParams videoSearchParams,
         Pageable pageable
     ) {
@@ -53,21 +54,21 @@ public class VideoService {
     }
 
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.SimpleVideo> getAllVideosDesc() {
+    public List<VideoQueryResult.DetailedVideo> getRecentVideos() {
         var top10Videos = recentVideoRepository.findAll();
 
-        return top10Videos.stream().map(SimpleVideo::from).toList();
+        return top10Videos.stream().map(DetailedVideo::from).toList();
     }
 
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.SimpleVideo> getCoolVideo() {
+    public List<VideoQueryResult.DetailedVideo> getCoolVideo() {
         var top10Videos = coolVideoRepository.findAll();
 
-        return top10Videos.stream().map(SimpleVideo::from).toList();
+        return top10Videos.stream().map(DetailedVideo::from).toList();
     }
 
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.SimpleVideo> getMyInfluencerVideos(Long userId) {
+    public List<VideoQueryResult.DetailedVideo> getMyInfluencerVideos(Long userId) {
         var top10Videos = videoReadRepository.findTop10ByLikedInfluencer(userId);
 
         return top10Videos.stream().toList();
@@ -131,28 +132,28 @@ public class VideoService {
     @Transactional
     public void updateCoolVideos() {
         // 인기순 top 10 video 가져오기
-        List<SimpleVideo> coolVideos = videoReadRepository.findTop10ByViewCountIncrement();
+        List<DetailedVideo> coolVideos = videoReadRepository.findTop10ByViewCountIncrement();
 
         // coolVideo table 업데이트하기
         coolVideoRepository.deleteAll();
         coolVideoRepository.flush(); // delete 후 save 하려면 flush를 해야함.
         coolVideoRepository.saveAll(
             coolVideos.stream()
-                .map(SimpleVideo::toCoolVideo).toList()
+                .map(DetailedVideo::toCoolVideo).toList()
         );
     }
 
     @Transactional
     public void updateRecentVideos() {
         //최신순 top 10 video 가져오기
-        List<SimpleVideo> recentVideos = videoReadRepository.findTop10ByLatestUploadDate();
+        List<DetailedVideo> recentVideos = videoReadRepository.findTop10ByLatestUploadDate();
 
         // recentVideo table 업데이트하기
         recentVideoRepository.deleteAll();
         recentVideoRepository.flush();
         recentVideoRepository.saveAll(
             recentVideos.stream()
-                .map(SimpleVideo::toRecentVideo).toList()
+                .map(DetailedVideo::toRecentVideo).toList()
         );
     }
 }

--- a/backend/src/main/java/team7/inplace/video/domain/CoolVideo.java
+++ b/backend/src/main/java/team7/inplace/video/domain/CoolVideo.java
@@ -42,18 +42,59 @@ public class CoolVideo {
     @Enumerated(value = EnumType.STRING)
     private Category placeCategory;
 
-    private CoolVideo(Long videoId, String videoUUID, String influencerName, Long placeId, String placeName,
-        Category placeCategory) {
+    @Column(name = "address1")
+    private String address1;
+
+    @Column(name = "address2")
+    private String address2;
+
+    @Column(name = "address3")
+    private String address3;
+
+    private CoolVideo(
+        Long videoId,
+        String videoUUID,
+        String influencerName,
+        Long placeId,
+        String placeName,
+        Category placeCategory,
+        String address1,
+        String address2,
+        String address3
+    ) {
         this.videoId = videoId;
         this.videoUUID = videoUUID;
         this.influencerName = influencerName;
         this.placeId = placeId;
         this.placeName = placeName;
         this.placeCategory = placeCategory;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.address3 = address3;
     }
 
-    public static CoolVideo from(Long videoId, String videoUUID, String influencerName, Long placeId, String placeName, Category placeCategory) {
-        return new CoolVideo(videoId, videoUUID, influencerName, placeId, placeName, placeCategory);
+    public static CoolVideo from(
+        Long videoId,
+        String videoUUID,
+        String influencerName,
+        Long placeId,
+        String placeName,
+        Category placeCategory,
+        String address1,
+        String address2,
+        String address3
+    ) {
+        return new CoolVideo(
+            videoId,
+            videoUUID,
+            influencerName,
+            placeId,
+            placeName,
+            placeCategory,
+            address1,
+            address2,
+            address3
+        );
     }
 
 }

--- a/backend/src/main/java/team7/inplace/video/domain/RecentVideo.java
+++ b/backend/src/main/java/team7/inplace/video/domain/RecentVideo.java
@@ -42,18 +42,59 @@ public class RecentVideo {
     @Enumerated(value = EnumType.STRING)
     private Category placeCategory;
 
-    private RecentVideo(Long videoId, String videoUUID, String influencerName, Long placeId, String placeName,
-        Category placeCategory) {
+    @Column(name = "address1")
+    private String address1;
+
+    @Column(name = "address2")
+    private String address2;
+
+    @Column(name = "address3")
+    private String address3;
+
+    private RecentVideo(
+        Long videoId,
+        String videoUUID,
+        String influencerName,
+        Long placeId,
+        String placeName,
+        Category placeCategory,
+        String address1,
+        String address2,
+        String address3
+    ) {
         this.videoId = videoId;
         this.videoUUID = videoUUID;
         this.influencerName = influencerName;
         this.placeId = placeId;
         this.placeName = placeName;
         this.placeCategory = placeCategory;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.address3 = address3;
     }
 
-    public static RecentVideo from(Long videoId, String videoUUID, String influencerName, Long placeId, String placeName, Category placeCategory) {
-        return new RecentVideo(videoId, videoUUID, influencerName, placeId, placeName, placeCategory);
+    public static RecentVideo from(
+        Long videoId,
+        String videoUUID,
+        String influencerName,
+        Long placeId,
+        String placeName,
+        Category placeCategory,
+        String address1,
+        String address2,
+        String address3
+    ) {
+        return new RecentVideo(
+            videoId,
+            videoUUID,
+            influencerName,
+            placeId,
+            placeName,
+            placeCategory,
+            address1,
+            address2,
+            address3
+        );
     }
 
 }

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import team7.inplace.video.persistence.dto.VideoQueryResult;
 
 public interface VideoReadRepository {
-    Page<VideoQueryResult.SimpleVideo> findSimpleVideosInSurround(
+    Page<VideoQueryResult.DetailedVideo> findSimpleVideosInSurround(
             Double topLeftLongitude,
             Double topLeftLatitude,
             Double bottomRightLongitude,
@@ -17,11 +17,11 @@ public interface VideoReadRepository {
             Pageable pageable
     );
 
-    List<VideoQueryResult.SimpleVideo> findTop10ByViewCountIncrement();
+    List<VideoQueryResult.DetailedVideo> findTop10ByViewCountIncrement();
 
-    List<VideoQueryResult.SimpleVideo> findTop10ByLatestUploadDate();
+    List<VideoQueryResult.DetailedVideo> findTop10ByLatestUploadDate();
 
-    List<VideoQueryResult.SimpleVideo> findTop10ByLikedInfluencer(Long userId);
+    List<VideoQueryResult.DetailedVideo> findTop10ByLikedInfluencer(Long userId);
 
     List<VideoQueryResult.SimpleVideo> findSimpleVideosByPlaceId(Long placeId);
 

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepositoryImpl.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepositoryImpl.java
@@ -17,8 +17,10 @@ import team7.inplace.liked.likedInfluencer.domain.QLikedInfluencer;
 import team7.inplace.liked.likedPlace.domain.QLikedPlace;
 import team7.inplace.place.domain.QPlace;
 import team7.inplace.video.domain.QVideo;
+import team7.inplace.video.persistence.dto.QVideoQueryResult_DetailedVideo;
 import team7.inplace.video.persistence.dto.QVideoQueryResult_SimpleVideo;
 import team7.inplace.video.persistence.dto.VideoQueryResult;
+import team7.inplace.video.persistence.dto.VideoQueryResult.DetailedVideo;
 import team7.inplace.video.persistence.dto.VideoQueryResult.SimpleVideo;
 
 @Repository
@@ -29,7 +31,7 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<VideoQueryResult.SimpleVideo> findSimpleVideosInSurround(
+    public Page<VideoQueryResult.DetailedVideo> findSimpleVideosInSurround(
         Double topLeftLongitude, Double topLeftLatitude,
         Double bottomRightLongitude, Double bottomRightLatitude,
         Double longitude, Double latitude,
@@ -50,13 +52,16 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
 
         // 페이징된 결과 조회
         var content = queryFactory
-            .select(new QVideoQueryResult_SimpleVideo(
+            .select(new QVideoQueryResult_DetailedVideo(
                 QVideo.video.id,
                 QVideo.video.uuid,
                 QInfluencer.influencer.name,
                 QPlace.place.id,
                 QPlace.place.name,
-                QPlace.place.category
+                QPlace.place.category,
+                QPlace.place.address.address1,
+                QPlace.place.address.address2,
+                QPlace.place.address.address3
             ))
             .from(QVideo.video)
             .join(QPlace.place).on(QVideo.video.placeId.eq(QPlace.place.id))
@@ -78,15 +83,18 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
     }
 
     @Override
-    public List<SimpleVideo> findTop10ByViewCountIncrement() {
+    public List<DetailedVideo> findTop10ByViewCountIncrement() {
         var top10Videos = queryFactory
-            .select(new QVideoQueryResult_SimpleVideo(
+            .select(new QVideoQueryResult_DetailedVideo(
                 QVideo.video.id,
                 QVideo.video.uuid,
                 QInfluencer.influencer.name,
                 QPlace.place.id,
                 QPlace.place.name,
-                QPlace.place.category
+                QPlace.place.category,
+                QPlace.place.address.address1,
+                QPlace.place.address.address2,
+                QPlace.place.address.address3
             ))
             .from(QVideo.video)
             .join(QPlace.place).on(QVideo.video.placeId.eq(QPlace.place.id))
@@ -105,15 +113,18 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
     }
 
     @Override
-    public List<SimpleVideo> findTop10ByLatestUploadDate() {
+    public List<DetailedVideo> findTop10ByLatestUploadDate() {
         var top10Videos = queryFactory
-            .select(new QVideoQueryResult_SimpleVideo(
+            .select(new QVideoQueryResult_DetailedVideo(
                 QVideo.video.id,
                 QVideo.video.uuid,
                 QInfluencer.influencer.name,
                 QPlace.place.id,
                 QPlace.place.name,
-                QPlace.place.category
+                QPlace.place.category,
+                QPlace.place.address.address1,
+                QPlace.place.address.address2,
+                QPlace.place.address.address3
             ))
             .from(QVideo.video)
             .join(QPlace.place).on(QVideo.video.placeId.eq(QPlace.place.id))
@@ -132,15 +143,18 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
     }
 
     @Override
-    public List<SimpleVideo> findTop10ByLikedInfluencer(Long userId) {
+    public List<DetailedVideo> findTop10ByLikedInfluencer(Long userId) {
         var top10Videos = queryFactory
-            .select(new QVideoQueryResult_SimpleVideo(
+            .select(new QVideoQueryResult_DetailedVideo(
                 QVideo.video.id,
                 QVideo.video.uuid,
                 QInfluencer.influencer.name,
                 QPlace.place.id,
                 QPlace.place.name,
-                QPlace.place.category
+                QPlace.place.category,
+                QPlace.place.address.address1,
+                QPlace.place.address.address2,
+                QPlace.place.address.address3
             ))
             .from(QVideo.video)
             .join(QPlace.place).on(QVideo.video.placeId.eq(QPlace.place.id))

--- a/backend/src/main/java/team7/inplace/video/persistence/dto/VideoQueryResult.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/dto/VideoQueryResult.java
@@ -21,34 +21,60 @@ public class VideoQueryResult {
         public String videoUrl() {
             return "https://www.youtube.com/watch?v=" + videoUUID;
         }
+    }
 
-        public CoolVideo toCoolVideo() {
-            return CoolVideo.from(videoId, videoUUID, influencerName, placeId, placeName, placeCategory);
+    public record DetailedVideo(
+        Long videoId,
+        String videoUUID,
+        String influencerName,
+        Long placeId,
+        String placeName,
+        Category placeCategory,
+        String address1,
+        String address2,
+        String address3
+    ) {
+        @QueryProjection
+        public DetailedVideo {
         }
 
-        public static SimpleVideo from(CoolVideo coolVideo) {
-            return new SimpleVideo(
+        public String videoUrl() {
+            return "https://www.youtube.com/watch?v=" + videoUUID;
+        }
+
+        public CoolVideo toCoolVideo() {
+            return CoolVideo.from(videoId, videoUUID, influencerName, placeId, placeName, placeCategory, address1, address2, address3);
+        }
+
+        public static DetailedVideo from(CoolVideo coolVideo) {
+            return new DetailedVideo(
                 coolVideo.getVideoId(),
                 coolVideo.getVideoUUID(),
                 coolVideo.getInfluencerName(),
                 coolVideo.getPlaceId(),
                 coolVideo.getPlaceName(),
-                coolVideo.getPlaceCategory()
+                coolVideo.getPlaceCategory(),
+                coolVideo.getAddress1(),
+                coolVideo.getAddress2(),
+                coolVideo.getAddress3()
             );
         }
 
         public RecentVideo toRecentVideo() {
-            return RecentVideo.from(videoId, videoUUID, influencerName, placeId, placeName, placeCategory);
+            return RecentVideo.from(videoId, videoUUID, influencerName, placeId, placeName, placeCategory, address1, address2, address3);
         }
 
-        public static SimpleVideo from(RecentVideo recentVideo) {
-            return new SimpleVideo(
+        public static DetailedVideo from(RecentVideo recentVideo) {
+            return new DetailedVideo(
                 recentVideo.getVideoId(),
                 recentVideo.getVideoUUID(),
                 recentVideo.getInfluencerName(),
                 recentVideo.getPlaceId(),
                 recentVideo.getPlaceName(),
-                recentVideo.getPlaceCategory()
+                recentVideo.getPlaceCategory(),
+                recentVideo.getAddress1(),
+                recentVideo.getAddress2(),
+                recentVideo.getAddress3()
             );
         }
     }

--- a/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -30,39 +30,39 @@ public class VideoController implements VideoControllerApiSpec {
     @Override
     @GetMapping()
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<VideoResponse.Simple>> readVideos(
+    public ResponseEntity<List<VideoResponse.Detail>> readVideos(
         @RequestParam(value = "longitude", defaultValue = "128.6") String longitude,
         @RequestParam(value = "latitude", defaultValue = "35.9") String latitude,
         @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
         VideoSearchParams searchParams = VideoSearchParams.from(longitude, latitude);
         var videoResponses = videoService.getVideosBySurround(searchParams, pageable)
-            .stream().map(VideoResponse.Simple::from).toList();
+            .stream().map(VideoResponse.Detail::from).toList();
         return new ResponseEntity<>(videoResponses, HttpStatus.OK);
     }
 
     @Override
     @GetMapping("/new")
-    public ResponseEntity<List<VideoResponse.Simple>> readByNew() {
-        var videoResponses = videoService.getAllVideosDesc()
-            .stream().map(VideoResponse.Simple::from).toList();
+    public ResponseEntity<List<VideoResponse.Detail>> readByNew() {
+        var videoResponses = videoService.getRecentVideos()
+            .stream().map(VideoResponse.Detail::from).toList();
         return new ResponseEntity<>(videoResponses, HttpStatus.OK);
     }
 
     @Override
     @GetMapping("/cool")
-    public ResponseEntity<List<VideoResponse.Simple>> readByCool() {
+    public ResponseEntity<List<VideoResponse.Detail>> readByCool() {
         var videoResponses = videoService.getCoolVideo()
-            .stream().map(VideoResponse.Simple::from).toList();
+            .stream().map(VideoResponse.Detail::from).toList();
         return new ResponseEntity<>(videoResponses, HttpStatus.OK);
     }
 
     @Override
     @GetMapping("/my")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<VideoResponse.Simple>> readByMyInfluencer() {
+    public ResponseEntity<List<VideoResponse.Detail>> readByMyInfluencer() {
         var myVideos = videoFacade.getMyInfluencerVideos()
-            .stream().map(VideoResponse.Simple::from).toList();
+            .stream().map(VideoResponse.Detail::from).toList();
         return new ResponseEntity<>(myVideos, HttpStatus.OK);
     }
 

--- a/backend/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
@@ -6,8 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import team7.inplace.video.presentation.dto.VideoResponse;
@@ -19,7 +17,7 @@ public interface VideoControllerApiSpec {
         summary = "내 주변 그곳 ",
         description = "Parameter로 입력받은 위치의 주변 장소 Video를 조회합니다."
     )
-    ResponseEntity<List<VideoResponse.Simple>> readVideos(
+    ResponseEntity<List<VideoResponse.Detail>> readVideos(
         @RequestParam String longitude,
         @RequestParam String latitude,
         @PageableDefault(page = 0, size = 10) Pageable pageable
@@ -29,19 +27,19 @@ public interface VideoControllerApiSpec {
         summary = "새로 등록된 그 곳",
         description = "id를 기준으로 내림차순 정렬한 Video 정보를 조회합니다."
     )
-    ResponseEntity<List<VideoResponse.Simple>> readByNew();
+    ResponseEntity<List<VideoResponse.Detail>> readByNew();
 
     @Operation(
         summary = "쿨한 그 곳",
         description = "조회수 증가량을 기준으로 내림차순 정렬한 Video 정보를 조회합니다."
     )
-    ResponseEntity<List<VideoResponse.Simple>> readByCool();
+    ResponseEntity<List<VideoResponse.Detail>> readByCool();
 
     @Operation(
         summary = "내 인플루언서의 비디오 반환",
         description = "내가 좋아요를 누른 인플루언서의 Video 정보를 조회합니다."
     )
-    ResponseEntity<List<VideoResponse.Simple>> readByMyInfluencer();
+    ResponseEntity<List<VideoResponse.Detail>> readByMyInfluencer();
 
     @Operation(
         summary = "비디오 삭제",

--- a/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
@@ -38,7 +38,11 @@ public class VideoResponse {
             var place = new VideoResponse.PlaceDetail(
                 videoInfo.placeId(),
                 videoInfo.placeName(),
-                String.join(" ", videoInfo.address1(), videoInfo.address2(), videoInfo.address3())
+                new Address(
+                    videoInfo.address1(),
+                    videoInfo.address2(),
+                    videoInfo.address3()
+                )
             );
             return new VideoResponse.Detail(
                 videoInfo.videoId(),
@@ -52,8 +56,16 @@ public class VideoResponse {
     public record PlaceDetail(
         Long placeId,
         String placeName,
-        String placeAddress
+        Address address
     ) {
+    }
+
+    public record Address(
+        String address1,
+        String address2,
+        String address3
+    ) {
+
     }
 
 }

--- a/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
@@ -1,13 +1,11 @@
 package team7.inplace.video.presentation.dto;
 
-import team7.inplace.video.application.AliasUtil;
 import team7.inplace.video.persistence.dto.VideoQueryResult;
 
 // Video 엔티티의 Controller Response 정보 전달을 담당하는 클래스
 public class VideoResponse {
     public record Simple(
             Long videoId,
-            String videoAlias,
             String videoUrl,
             VideoResponse.Place place
     ) {
@@ -18,7 +16,6 @@ public class VideoResponse {
             );
             return new VideoResponse.Simple(
                     videoInfo.videoId(),
-                    AliasUtil.makeAlias(videoInfo.influencerName(), videoInfo.placeCategory()),
                     videoInfo.videoUrl(),
                     place
             );
@@ -30,4 +27,33 @@ public class VideoResponse {
             String placeName
     ) {
     }
+
+    public record Detail(
+        Long videoId,
+        String influencerName,
+        String videoUrl,
+        VideoResponse.PlaceDetail place
+    ) {
+        public static VideoResponse.Detail from(VideoQueryResult.DetailedVideo videoInfo) {
+            var place = new VideoResponse.PlaceDetail(
+                videoInfo.placeId(),
+                videoInfo.placeName(),
+                String.join(" ", videoInfo.address1(), videoInfo.address2(), videoInfo.address3())
+            );
+            return new VideoResponse.Detail(
+                videoInfo.videoId(),
+                videoInfo.influencerName(),
+                videoInfo.videoUrl(),
+                place
+            );
+        }
+    }
+
+    public record PlaceDetail(
+        Long placeId,
+        String placeName,
+        String placeAddress
+    ) {
+    }
+
 }

--- a/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
+++ b/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
@@ -53,7 +53,7 @@ public class VideoReadRepositoryTest {
         final int expectedContentSize = 5;
 
         // when
-        Page<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findSimpleVideosInSurround(
+        Page<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findSimpleVideosInSurround(
                 topLeftLongitude, topLeftLatitude, bottomRightLongitude, bottomRightLatitude, longitude, latitude, pageable
         );
 
@@ -70,11 +70,11 @@ public class VideoReadRepositoryTest {
         final List<Long> expectedVideoIds = List.of(20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L);
 
         // when
-        List<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findTop10ByViewCountIncrement();
+        List<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findTop10ByViewCountIncrement();
 
         // then
         assertThat(videos.size()).isEqualTo(expectedTotalContent);
-        assertThat(videos.stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
+        assertThat(videos.stream().map(VideoQueryResult.DetailedVideo::videoId).toList())
                 .isEqualTo(expectedVideoIds);
     }
 
@@ -86,11 +86,11 @@ public class VideoReadRepositoryTest {
         final List<Long> expectedVideoIds = List.of(20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L);
 
         // when
-        List<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findTop10ByLatestUploadDate();
+        List<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findTop10ByLatestUploadDate();
 
         // then
         assertThat(videos.size()).isEqualTo(expectedTotalContent);
-        assertThat(videos.stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
+        assertThat(videos.stream().map(VideoQueryResult.DetailedVideo::videoId).toList())
                 .isEqualTo(expectedVideoIds);
     }
 
@@ -102,11 +102,11 @@ public class VideoReadRepositoryTest {
         final List<Long> expectedVideoIds = List.of(20L, 19L, 18L, 17L, 8L, 7L, 6L, 5L, 4L, 3L);
 
         // when
-        List<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findTop10ByLikedInfluencer(1L);
+        List<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findTop10ByLikedInfluencer(1L);
 
         // then
         assertThat(videos.size()).isEqualTo(expectedTotalContent);
-        assertThat(videos.stream().map(VideoQueryResult.SimpleVideo::videoId).toList())
+        assertThat(videos.stream().map(VideoQueryResult.DetailedVideo::videoId).toList())
                 .isEqualTo(expectedVideoIds);
     }
 


### PR DESCRIPTION
### ✨ 작업 내용
- 메인 페이지의 비디오 반환시 비디오 별칭 삭제 및 인플루언서 이름, 세부 주소 추가
  - CoolVideo, RecentVideo 도메인에 address1, 2, 3 추가
  - 세부 주소를 포함한 VideoQueryResult.DetailedVideo, VideoResponse.Detail 레코드 추가
  - Address로 반환
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
