### PR TITLE
[INPLACE-227] 구글 태그 매니저 연결

### DIFF
--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          VITE_GOOGLE_ANALYTICS: ${{ secrets.VITE_GOOGLE_ANALYTICS }}
+          VITE_GOOGLE_TAG: ${{ secrets.VITE_GOOGLE_TAG }}
           VITE_KAKAO_REST_KEY: ${{ secrets.VITE_KAKAO_REST_KEY }}
 
       - name: Configure AWS credentials

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,17 +8,20 @@
     <title>인플레이스</title>
     <meta name="description" content="긴 영상은 필요 없어요 인플루언서가 다녀간 쿨플, 한눈에 쏙!" />
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6NZ28NWMQH"></script>
+    <!-- Google Tag Manager -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', '%VITE_GOOGLE_ANALYTICS%');
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', '%VITE_GOOGLE_TAG%');
     </script>
+    <!-- End Google Tag Manager -->
 
     <meta name="google-site-verification" content="LalfUvjq4fhMfp9zXc5gIehoFod4FKOH6AlkmqZS0aA" />
     <meta name="naver-site-verification" content="5fc8108ba5c1353d68cbcf8b2c5340ea269eae56" />
@@ -39,6 +42,17 @@
     <link rel="preconnect" href="https://api.inplace.my" crossorigin="anonymous" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=%VITE_GOOGLE_TAG%"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div id="root"></div>
     <script type="module" src="/src/main.tsx" defer></script>
     <script

--- a/frontend/src/components/Detail/InfoTap/SpeedDialMap.tsx
+++ b/frontend/src/components/Detail/InfoTap/SpeedDialMap.tsx
@@ -35,13 +35,13 @@ export default function SpeedDialMap({
 
   return (
     <SpeedDialContainer>
-      <MainButton aria-label="toggle_map_options" variant={buttonVariant} onClick={toggleSpeedDial}>
+      <MainButton aria-label="스피드 다이얼" variant={buttonVariant} onClick={toggleSpeedDial}>
         {isOpen ? <IoClose size={30} /> : <FaMapMarkedAlt size={24} />}
       </MainButton>
 
       <SpeedDialItems $isOpen={isOpen}>
         <KakaoButton
-          aria-label="kakao_btn"
+          aria-label="카카오 지도"
           variant="white"
           onClick={() => {
             window.open(kakaoPlaceUrl, '_blank');
@@ -52,7 +52,7 @@ export default function SpeedDialMap({
         </KakaoButton>
 
         <SpeedDialItem
-          aria-label="naver_btn"
+          aria-label="네이버 지도"
           variant="white"
           onClick={() => {
             window.open(naverPlaceUrl, '_blank');
@@ -64,7 +64,7 @@ export default function SpeedDialMap({
 
         {googlePlaceUrl && (
           <GoogleButton
-            aria-label="google_btn"
+            aria-label="구글 지도"
             variant="white"
             onClick={() => {
               window.open(googlePlaceUrl, '_blank');
@@ -76,7 +76,7 @@ export default function SpeedDialMap({
         )}
         {!isMobile ? (
           <SpeedDialItem
-            aria-label="mobile_qr_btn"
+            aria-label="모바일로 연결"
             variant="white"
             onClick={() => setVisitModal(!visitModal)}
             data-tooltip="모바일로 연결"

--- a/frontend/src/components/Detail/ReviewTap/ReviewItem.tsx
+++ b/frontend/src/components/Detail/ReviewTap/ReviewItem.tsx
@@ -44,7 +44,7 @@ export default function ReviewItem({ reviewId, likes, comment, userNickname, cre
           {comment}
         </Paragraph>
         {mine ? (
-          <DeleteBtn aria-label="delete_btn" onClick={handleReviewDelete}>
+          <DeleteBtn aria-label="리뷰 삭제" onClick={handleReviewDelete}>
             삭제
           </DeleteBtn>
         ) : null}

--- a/frontend/src/components/Detail/VisitModal.tsx
+++ b/frontend/src/components/Detail/VisitModal.tsx
@@ -61,7 +61,7 @@ export default function VisitModal({ id, onClose }: { id: number; onClose: () =>
             {qrSrc && <Image src={qrSrc} alt="QR CODE" />}
           </ImageFrame>
           <BtnContainer>
-            <Button aria-label="complete_btn" variant="mint" size="small" onClick={() => onClose()}>
+            <Button aria-label="큐알코드 닫기" variant="mint" size="small" onClick={() => onClose()}>
               닫기
             </Button>
           </BtnContainer>

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfluencerMapWindow.tsx
@@ -178,7 +178,7 @@ export default function InfluencerMapWindow({
         </Map>
         <ResetButtonContainer>
           <StyledBtn
-            aria-label="reset_btn"
+            aria-label="인플루언서 내위치"
             onClick={() => userLocation && handleCenterReset(userLocation)}
             variant="white"
             size="small"
@@ -187,14 +187,14 @@ export default function InfluencerMapWindow({
           </StyledBtn>
         </ResetButtonContainer>
         {!isListExpanded && (
-          <ListViewButton onClick={() => onListExpand && onListExpand(true)}>
+          <ListViewButton aria-label="인플루언서 지도 목록보기" onClick={() => onListExpand && onListExpand(true)}>
             <Text size="xs" variant="white" weight="normal">
               목록 보기
             </Text>
           </ListViewButton>
         )}
       </MapContainer>
-      <Btn onClick={handleNearbySearch}>
+      <Btn aria-label="인플루언서 지도 리프레시" onClick={handleNearbySearch}>
         <GrPowerCycle />
         현재 위치에서 장소정보 보기
       </Btn>

--- a/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfoWindow.tsx
+++ b/frontend/src/components/InfluencerInfo/InfluencerMapTap/InfoWindow.tsx
@@ -48,7 +48,7 @@ export default function InfoWindow({ data }: Props) {
       <Info>
         <ImageSection>
           {totalVideos > 1 && (
-            <NavButton $left onClick={prevImage} disabled={currentIndex === 0}>
+            <NavButton aria-label="인포윈도우 왼쪽 화살표" $left onClick={prevImage} disabled={currentIndex === 0}>
               <GrPrevious size={20} />
             </NavButton>
           )}
@@ -66,7 +66,12 @@ export default function InfoWindow({ data }: Props) {
             </ImgWrapper>
           </ImageContainer>
           {totalVideos > 1 && (
-            <NavButton $right onClick={nextImage} disabled={currentIndex === videos.length - 1}>
+            <NavButton
+              aria-label="인포윈도우 오른쪽 화살표"
+              $right
+              onClick={nextImage}
+              disabled={currentIndex === videos.length - 1}
+            >
               <GrNext size={20} />
             </NavButton>
           )}
@@ -98,7 +103,9 @@ export default function InfoWindow({ data }: Props) {
           </Text>
         </TextInfo>
       </Info>
-      <DetailBtn onClick={(e: React.MouseEvent<HTMLDivElement>) => handleInfoClick(e)}>상세보기</DetailBtn>
+      <DetailBtn aria-label="상세보기" onClick={(e: React.MouseEvent<HTMLDivElement>) => handleInfoClick(e)}>
+        상세보기
+      </DetailBtn>
     </Wrapper>
   );
 }

--- a/frontend/src/components/Main/InfluencerSection/index.tsx
+++ b/frontend/src/components/Main/InfluencerSection/index.tsx
@@ -28,7 +28,12 @@ export default function InfluencerSection({ items = [] }: { items: InfluencerDat
         <NoItem message="인플루언서 정보가 없어요!" height={200} />
       ) : (
         <>
-          <ArrowButton aria-label="left_btn" onClick={() => scrollList('left')} className="left-arrow" direction="left">
+          <ArrowButton
+            aria-label="인플루언서 스크롤 왼쪽"
+            onClick={() => scrollList('left')}
+            className="left-arrow"
+            direction="left"
+          >
             <GrPrevious size={40} />
           </ArrowButton>
           <ListContainer ref={listRef}>
@@ -47,7 +52,7 @@ export default function InfluencerSection({ items = [] }: { items: InfluencerDat
           </ListContainer>
           {items.length > 5 && (
             <ArrowButton
-              aria-label="right_btn"
+              aria-label="인플루언서 스크롤 오른쪽"
               onClick={() => scrollList('right')}
               className="right-arrow"
               direction="right"

--- a/frontend/src/components/Main/MainBanner/index.tsx
+++ b/frontend/src/components/Main/MainBanner/index.tsx
@@ -145,13 +145,17 @@ export default function MainBanner({ items = [] }: { items: BannerData[] }) {
         <NoItem message="배너 정보가 없어요!" height={400} />
       ) : (
         <>
-          <PrevBtn aria-label="prev_btn" onClick={handleBtnPrevClick} disabled={currentIndex === 0 || isReturning}>
+          <PrevBtn
+            aria-label="배너 스크롤 왼쪽"
+            onClick={handleBtnPrevClick}
+            disabled={currentIndex === 0 || isReturning}
+          >
             <PrevIconWrapper>
               <GrPrevious size={40} />
             </PrevIconWrapper>
           </PrevBtn>
           <NextBtn
-            aria-label="next_btn"
+            aria-label="배너 스크롤 오른쪽"
             onClick={handleBtnNextClick}
             disabled={currentIndex === (isMobile ? sortedItems.length - 1 : sortedItems.length - 2) || isReturning}
           >

--- a/frontend/src/components/Main/MapSection/index.tsx
+++ b/frontend/src/components/Main/MapSection/index.tsx
@@ -48,7 +48,7 @@ export default function MapSection({ highlightText, mainText }: MapSectionProps)
             <img src={VisitPlace} alt="방문 장소" width={isMobile ? '30px' : '44px'} />
           </IconContainer>
         </TextSection>
-        <ConfirmButton onClick={handleConfirmClick}>
+        <ConfirmButton aria-label="지도로 이동 섹션" onClick={handleConfirmClick}>
           {isMobile ? '보기' : '확인하러 가기'}
           <FaChevronRight size={isMobile ? 10 : 12} />
         </ConfirmButton>

--- a/frontend/src/components/Main/SpotSection/index.tsx
+++ b/frontend/src/components/Main/SpotSection/index.tsx
@@ -27,7 +27,12 @@ export default function SpotSection({ items = [] }: { items: SpotData[] }) {
         <NoItem message="그곳 정보가 없어요!" height={200} />
       ) : (
         <>
-          <ArrowButton aria-label="left_btn" onClick={() => scrollList('left')} className="left-arrow" direction="left">
+          <ArrowButton
+            aria-label="그곳 스크롤 왼쪽"
+            onClick={() => scrollList('left')}
+            className="left-arrow"
+            direction="left"
+          >
             <GrPrevious size={40} />
           </ArrowButton>
           <ListContainer ref={listRef}>
@@ -45,7 +50,7 @@ export default function SpotSection({ items = [] }: { items: SpotData[] }) {
           </ListContainer>
           {items.length > 3 && (
             <ArrowButton
-              aria-label="right_btn"
+              aria-label="그곳 스크롤 오른쪽"
               onClick={() => scrollList('right')}
               className="right-arrow"
               direction="right"

--- a/frontend/src/components/Map/DropdownFilterBar/DropdownMenu.tsx
+++ b/frontend/src/components/Map/DropdownFilterBar/DropdownMenu.tsx
@@ -121,7 +121,7 @@ export default function DropdownMenu({
   };
   return (
     <DropdownContainer ref={dropdownRef} type={type} $width={width}>
-      <DropdownButton aria-label="dropdown_btn" $isOpen={isOpen} onClick={handleDropdownToggle}>
+      <DropdownButton aria-label={`${type}_필터링`} $isOpen={isOpen} onClick={handleDropdownToggle}>
         {displayIcon()}
         {displayValue}
       </DropdownButton>

--- a/frontend/src/components/Map/MapSearchBar/index.tsx
+++ b/frontend/src/components/Map/MapSearchBar/index.tsx
@@ -158,7 +158,7 @@ export default function MapSearchBar({ setIsChangedLocation, setSelectedPlaceNam
         <SearchType ref={searchTypeRef}>
           <DropdownButton
             type="button"
-            aria-label="searchType_btn"
+            aria-label="지도 검색바 타입"
             onClick={() => {
               setIsTypeOpen(!isTypeOpen);
               setIsOpen(false);
@@ -171,6 +171,7 @@ export default function MapSearchBar({ setIsChangedLocation, setSelectedPlaceNam
             <OptionsContainer>
               <TypeItem
                 className={searchType === 'location' ? 'selected' : ''}
+                aria-label="지도 위치 검색"
                 onClick={() => {
                   setSearchType('location');
                   setIsTypeOpen(false);
@@ -181,6 +182,7 @@ export default function MapSearchBar({ setIsChangedLocation, setSelectedPlaceNam
               </TypeItem>
               <TypeItem
                 className={searchType === 'place' ? 'selected' : ''}
+                aria-label="지도 장소 검색"
                 onClick={() => {
                   setSearchType('place');
                   setIsTypeOpen(false);
@@ -198,7 +200,7 @@ export default function MapSearchBar({ setIsChangedLocation, setSelectedPlaceNam
           onKeyDown={handleDropDownKey}
           placeholder={placeholder}
         />
-        <SearchRemoveButton aria-label="search-remove-btn" onClick={handleSearchRemoveClick}>
+        <SearchRemoveButton aria-label="지도 검색어 삭제" onClick={handleSearchRemoveClick}>
           {inputValue ? <IoIosClose size={26} color="#292929" /> : <IoIosSearch size={20} color="#292929" />}
         </SearchRemoveButton>
       </SearchForm>

--- a/frontend/src/components/Map/MapWindow/index.tsx
+++ b/frontend/src/components/Map/MapWindow/index.tsx
@@ -249,7 +249,7 @@ export default function MapWindow({
       {showSearchButton && (
         <ButtonContainer>
           <Button
-            aria-label="around_btn"
+            aria-label="지도 리프레시"
             onClick={handleNearbyClick}
             variant="white"
             size="small"
@@ -324,7 +324,7 @@ export default function MapWindow({
       </Map>
       <ResetButtonContainer>
         <StyledBtn
-          aria-label="reset_btn"
+          aria-label="지도 내위치"
           onClick={() => userLocation && handleCenterReset(userLocation)}
           variant="white"
           size="small"
@@ -333,7 +333,7 @@ export default function MapWindow({
         </StyledBtn>
       </ResetButtonContainer>
       {!isListExpanded && (
-        <ListViewButton onClick={onListExpand}>
+        <ListViewButton aria-label="지도 목록보기" onClick={onListExpand}>
           <Text size="xs" weight="normal" variant="white">
             목록 보기
           </Text>

--- a/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
+++ b/frontend/src/components/Map/PlaceSection/PlaceItem.tsx
@@ -91,7 +91,7 @@ export default function PlaceItem({
         <LikeContainer>
           <LikeIcon
             role="button"
-            aria-label="like_btn"
+            aria-label="장소 좋아요"
             onClick={(e: React.MouseEvent<HTMLDivElement>) => handleLikeClick(e)}
           >
             {isLike ? (

--- a/frontend/src/components/Map/ToggleButton/index.tsx
+++ b/frontend/src/components/Map/ToggleButton/index.tsx
@@ -43,7 +43,7 @@ export default function ToggleButton({ options, onSelect }: ToggleButtonProps) {
           <ButtonText $isActive={selectedOptions.includes(option)}>{categoryMapping[option]}</ButtonText>
           {selectedOptions.includes(option) && (
             <CheckIconWrapper>
-              <FaCheck color="#FFFFFF" size={10} />
+              <FaCheck color="red" size={10} />
             </CheckIconWrapper>
           )}
         </Button>

--- a/frontend/src/components/My/InfiniteScrollSection.tsx
+++ b/frontend/src/components/My/InfiniteScrollSection.tsx
@@ -61,7 +61,12 @@ export default function InfiniteScrollSection<T>({
         <NoItem message={noItemMessage} height={200} />
       ) : (
         <>
-          <ArrowButton aria-label="left_btn" onClick={() => scrollList('left')} className="left-arrow" direction="left">
+          <ArrowButton
+            aria-label="무한스크롤 왼쪽"
+            onClick={() => scrollList('left')}
+            className="left-arrow"
+            direction="left"
+          >
             <GrPrevious size={30} />
           </ArrowButton>
           <ListContainer ref={listRef} $type={type}>
@@ -74,7 +79,7 @@ export default function InfiniteScrollSection<T>({
           </ListContainer>
           {items.length > 5 && (
             <ArrowButton
-              aria-label="right_btn"
+              aria-label="무한스크롤 오른쪽"
               onClick={() => scrollList('right')}
               className="right-arrow"
               direction="right"

--- a/frontend/src/components/My/UserPlaceSection/index.tsx
+++ b/frontend/src/components/My/UserPlaceSection/index.tsx
@@ -28,7 +28,12 @@ export default function UserPlaceSection({ items = [] }: { items: UserPlaceData[
         <NoItem message="장소 정보가 없어요!" height={180} />
       ) : (
         <>
-          <ArrowButton aria-label="left_btn" onClick={() => scrollList('left')} className="left-arrow" direction="left">
+          <ArrowButton
+            aria-label="마이 장소 왼쪽"
+            onClick={() => scrollList('left')}
+            className="left-arrow"
+            direction="left"
+          >
             <GrPrevious size={30} />
           </ArrowButton>
           <ListContainer ref={listRef}>
@@ -48,7 +53,7 @@ export default function UserPlaceSection({ items = [] }: { items: UserPlaceData[
           </ListContainer>
           {items.length > 5 && (
             <ArrowButton
-              aria-label="right_btn"
+              aria-label="마이 장소 오른쪽"
               onClick={() => scrollList('right')}
               className="right-arrow"
               direction="right"

--- a/frontend/src/components/Review/steps/CommentStep.tsx
+++ b/frontend/src/components/Review/steps/CommentStep.tsx
@@ -76,10 +76,10 @@ export default function CommentStep({ isLiked, onBack, onSubmit, placeInfo }: Co
       <CharCount>{content.length} / 200</CharCount>
 
       <ButtonSection>
-        <CancelButton aria-label="cancel_btn" onClick={onBack}>
+        <CancelButton aria-label="리뷰 취소" onClick={onBack}>
           취소
         </CancelButton>
-        <SubmitButton aria-label="submit_btn" onClick={() => onSubmit(content)}>
+        <SubmitButton aria-label="리뷰 등록" onClick={() => onSubmit(content)}>
           등록
         </SubmitButton>
       </ButtonSection>

--- a/frontend/src/components/Review/steps/RatingStep.tsx
+++ b/frontend/src/components/Review/steps/RatingStep.tsx
@@ -53,12 +53,12 @@ export default function RatingStep({ onSubmit, placeInfo }: RatingStepProps) {
       </PlaceSection>
 
       <RatingSection>
-        <RatingButton aria-label="like_btn" onClick={() => onSubmit(true)} buttonType="like">
+        <RatingButton aria-label="리뷰 좋았어요" onClick={() => onSubmit(true)} buttonType="like">
           <AiFillLike size={50} />
           <ButtonText>좋았어요</ButtonText>
         </RatingButton>
 
-        <RatingButton aria-label="dislike_btn" onClick={() => onSubmit(false)} buttonType="dislike">
+        <RatingButton aria-label="리뷰 아쉬워요" onClick={() => onSubmit(false)} buttonType="dislike">
           <AiFillDislike size={50} />
           <ButtonText>아쉬워요</ButtonText>
         </RatingButton>

--- a/frontend/src/components/common/BaseLayout.tsx
+++ b/frontend/src/components/common/BaseLayout.tsx
@@ -80,7 +80,7 @@ export default function BaseLayout({
           {SubText}
         </Paragraph>
         {type === 'influencer' && showMoreButton ? (
-          <MoreBtn aria-label="more_btn" onClick={() => navigate('/influencer')}>
+          <MoreBtn aria-label="더보기 버튼" onClick={() => navigate('/influencer')}>
             더보기
           </MoreBtn>
         ) : null}

--- a/frontend/src/components/common/Chip/index.tsx
+++ b/frontend/src/components/common/Chip/index.tsx
@@ -17,7 +17,7 @@ export default function Chip({ selectedInfluencers, selectedCategories, onClearI
           <Text size="xxs" weight="normal" variant="#36617f">
             {influencer}
           </Text>
-          <ClearButton aria-label="infl-clear_btn" onClick={() => onClearInfluencer(influencer)}>
+          <ClearButton aria-label="인플루언서 칩 제거" onClick={() => onClearInfluencer(influencer)}>
             <IoClose size={14} />
           </ClearButton>
         </FilterChip>
@@ -28,7 +28,7 @@ export default function Chip({ selectedInfluencers, selectedCategories, onClearI
           <Text size="xxs" weight="normal" variant="#36617f">
             {category}
           </Text>
-          <ClearButton aria-label="cate-clear_btn" onClick={() => onClearCategory(category)}>
+          <ClearButton aria-label="카테고리 칩 제거" onClick={() => onClearCategory(category)}>
             <IoClose size={14} />
           </ClearButton>
         </FilterChip>

--- a/frontend/src/components/common/Items/InfluencerItem.tsx
+++ b/frontend/src/components/common/Items/InfluencerItem.tsx
@@ -62,7 +62,7 @@ export default function InfluencerItem({
         <ImageContainer>
           <LikeIcon
             role="button"
-            aria-label="like_btn"
+            aria-label="인플루언서 좋아요"
             onClick={(e: React.MouseEvent<HTMLDivElement>) => handleLikeClick(e)}
           >
             {isLike ? (

--- a/frontend/src/components/common/Pagination/index.tsx
+++ b/frontend/src/components/common/Pagination/index.tsx
@@ -54,20 +54,28 @@ export default function Pagination({
 
   return (
     <PaginationContainer>
-      <ArrowButton aria-label="left_btn" onClick={() => handlePageChange(currentPage - 1)} disabled={isFirstPage}>
+      <ArrowButton
+        aria-label="페이지네이션 왼쪽"
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={isFirstPage}
+      >
         <IoChevronBack size={20} />
       </ArrowButton>
       {pageNumbers.map((pageNum) => (
         <PageNumber
           key={pageNum}
-          aria-label={`page_number_${pageNum}`}
+          aria-label={`${pageNum}_페이지`}
           onClick={() => handlePageChange(pageNum)}
           $active={pageNum === currentPage}
         >
           {pageNum}
         </PageNumber>
       ))}
-      <ArrowButton aria-label="right_btn" onClick={() => handlePageChange(currentPage + 1)} disabled={isLastPage}>
+      <ArrowButton
+        aria-label="페이지네이션 오른쪽"
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={isLastPage}
+      >
         <IoChevronForward size={20} />
       </ArrowButton>
     </PaginationContainer>

--- a/frontend/src/components/common/SearchBarA.tsx
+++ b/frontend/src/components/common/SearchBarA.tsx
@@ -98,7 +98,7 @@ export default function SearchBar({ placeholder = '키워드를 입력해주세�
           onKeyDown={handleDropDownKey}
           placeholder={placeholder}
         />
-        <SearchIconWrapper role="button" aria-label="검색" onClick={() => handleSearch(inputValue)} />
+        <SearchIconWrapper role="button" aria-label="검색바 아이콘 버튼_A" onClick={() => handleSearch(inputValue)} />
       </SearchInputWrapper>
       {inputValue && isOpen && (
         <SearchDropDownBox>

--- a/frontend/src/components/common/SearchBarB.tsx
+++ b/frontend/src/components/common/SearchBarB.tsx
@@ -160,7 +160,7 @@ export default function SearchBar({
             $isSearchPage={isSearchPage}
           />
           {isSearchPage && (
-            <SearchButton type="submit" aria-label="검색" $isSearchPage={isSearchPage}>
+            <SearchButton type="submit" aria-label="검색페이지 아이콘 버튼_B" $isSearchPage={isSearchPage}>
               <SearchIcon $isExpanded />
             </SearchButton>
           )}
@@ -169,7 +169,12 @@ export default function SearchBar({
 
       <ButtonContainer $isSearchPage={isSearchPage}>
         {!isSearchPage && (
-          <SearchButton type="button" aria-label="검색" onClick={toggleSearchBar} $isSearchPage={isSearchPage}>
+          <SearchButton
+            type="button"
+            aria-label="검색바 아이콘 버튼_B"
+            onClick={toggleSearchBar}
+            $isSearchPage={isSearchPage}
+          >
             <SearchIcon $isExpanded={isExpanded} />
           </SearchButton>
         )}

--- a/frontend/src/components/common/layouts/Error.tsx
+++ b/frontend/src/components/common/layouts/Error.tsx
@@ -96,7 +96,7 @@ export default function ErrorComponent({ error, resetErrorBoundary }: FallbackPr
           {message.description}
         </Paragraph>
       </TextWrapper>
-      <StyledButton aria-label="retry-btn" variant={buttonVariant} size="large" onClick={handleRetry}>
+      <StyledButton aria-label="에러페이지 재시도" variant={buttonVariant} size="large" onClick={handleRetry}>
         {error instanceof AxiosError && error.response?.status !== 401 && error.response?.status !== 403
           ? '다시 시도하기'
           : '홈으로 가기'}

--- a/frontend/src/components/common/layouts/Header/AuthButtonsA.tsx
+++ b/frontend/src/components/common/layouts/Header/AuthButtonsA.tsx
@@ -31,7 +31,7 @@ export default function AuthButtons() {
           )}
         </LoginModal>
       )}
-      <ThemeButton onClick={toggleTheme} aria-label="테마 변경 버튼" $isDarkMode={isDarkMode}>
+      <ThemeButton onClick={toggleTheme} aria-label="테마 변경 버튼_A" $isDarkMode={isDarkMode}>
         {isDarkMode ? <FiSun size={20} color="white" /> : <FiMoon size={20} color="black" />}
       </ThemeButton>
     </Container>

--- a/frontend/src/components/common/layouts/Header/AuthButtonsB.tsx
+++ b/frontend/src/components/common/layouts/Header/AuthButtonsB.tsx
@@ -46,7 +46,7 @@ export default function AuthButtons() {
 
   return (
     <Container>
-      <ThemeButton onClick={toggleTheme} aria-label="테마 변경 버튼" $isDarkMode={isDarkMode}>
+      <ThemeButton onClick={toggleTheme} aria-label="테마 변경 버튼_B" $isDarkMode={isDarkMode}>
         {isDarkMode ? <FiSun size={24} color="white" /> : <FiMoon size={22} color="black" />}
       </ThemeButton>
       {isAuthenticated ? (

--- a/frontend/src/components/common/layouts/Header/DesktopNavA.tsx
+++ b/frontend/src/components/common/layouts/Header/DesktopNavA.tsx
@@ -32,6 +32,7 @@ export default function DesktopNavA() {
   return (
     <NavLinksContainer>
       <NavExternalLink
+        aria-label="헤더 설문조사_A"
         href="https://docs.google.com/forms/d/e/1FAIpQLSeBJcQg0gcVv2au5oFZ1aCLF9O_qbEiJCvnLEd0d1SSLLpDUA/viewform?pli=1"
         target="_blank"
         rel="noopener noreferrer"
@@ -41,20 +42,20 @@ export default function DesktopNavA() {
         </Text>
       </NavExternalLink>
 
-      <NavButton onClick={handleMapNavigation} $isActive={isActive('/map')}>
+      <NavButton aria-label="헤더 지도_A" onClick={handleMapNavigation} $isActive={isActive('/map')}>
         <Text size="xs" weight="normal">
           지도
         </Text>
       </NavButton>
 
-      <NavItem to="/influencer" $isActive={isActive('/influencer')}>
+      <NavItem aria-label="헤더 인플루언서_A" to="/influencer" $isActive={isActive('/influencer')}>
         <Text size="xs" weight="normal">
           인플루언서
         </Text>
       </NavItem>
 
       {isAuthenticated && (
-        <NavItem to="/my" $isActive={isActive('/my')}>
+        <NavItem to="/my" aria-label="헤더 마이페이지_A" $isActive={isActive('/my')}>
           <Text size="xs" weight="normal">
             마이페이지
           </Text>

--- a/frontend/src/components/common/layouts/Header/DesktopNavB.tsx
+++ b/frontend/src/components/common/layouts/Header/DesktopNavB.tsx
@@ -35,19 +35,20 @@ export default function DesktopNavB() {
         href="https://docs.google.com/forms/d/e/1FAIpQLSeBJcQg0gcVv2au5oFZ1aCLF9O_qbEiJCvnLEd0d1SSLLpDUA/viewform?pli=1"
         target="_blank"
         rel="noopener noreferrer"
+        aria-label="헤더 설문조사_B"
       >
         <Text size="m" weight="normal">
           설문조사
         </Text>
       </NavExternalLink>
 
-      <NavButton onClick={handleMapNavigation} $isActive={isActive('/map')}>
+      <NavButton aria-label="헤더 지도_B" onClick={handleMapNavigation} $isActive={isActive('/map')}>
         <Text size="m" weight="normal">
           지도
         </Text>
       </NavButton>
 
-      <NavItem to="/influencer" $isActive={isActive('/influencer')}>
+      <NavItem to="/influencer" aria-label="헤더 인플루언서_B" $isActive={isActive('/influencer')}>
         <Text size="m" weight="normal">
           인플루언서
         </Text>
@@ -59,7 +60,7 @@ export default function DesktopNavB() {
           pointerEvents: isAuthenticated ? 'auto' : 'none',
         }}
       >
-        <NavItem to="/my" $isActive={isActive('/my')}>
+        <NavItem to="/my" aria-label="헤더 마이페이지_B" $isActive={isActive('/my')}>
           <Text size="m" weight="normal">
             마이페이지
           </Text>

--- a/frontend/src/components/common/layouts/Header/LogoSection.tsx
+++ b/frontend/src/components/common/layouts/Header/LogoSection.tsx
@@ -5,7 +5,7 @@ import { Text } from '@/components/common/typography/Text';
 
 export default function LogoSection() {
   return (
-    <LogoLink to="/">
+    <LogoLink aria-label="홈 로고" to="/">
       <LogoContainer>
         <LogoImage src={Logo} alt="인플레이스 로고" />
         <Text size="l" weight="bold" variant="mint">

--- a/frontend/src/components/common/layouts/Header/MobileNav.tsx
+++ b/frontend/src/components/common/layouts/Header/MobileNav.tsx
@@ -68,6 +68,7 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
             to="https://docs.google.com/forms/d/e/1FAIpQLSeBJcQg0gcVv2au5oFZ1aCLF9O_qbEiJCvnLEd0d1SSLLpDUA/viewform?pli=1"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="모바일 설문조사"
             onClick={onClose}
           >
             <Text size="xs" weight="normal">
@@ -77,7 +78,7 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
         )}
 
         {commonLinks.map((link) => (
-          <NavItem key={link.to} to={link.to} onClick={onClose}>
+          <NavItem key={link.to} to={link.to} aria-label={`모바일 ${link.label}`} onClick={onClose}>
             <Text size="xs" weight="normal">
               {link.label}
             </Text>
@@ -86,7 +87,7 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
 
         {isAuthenticated ? (
           <>
-            <NavItem to="/my" onClick={onClose}>
+            <NavItem to="/my" aria-label="모바일 마이페이지" onClick={onClose}>
               <Text size="xs" weight="normal">
                 마이페이지
               </Text>

--- a/frontend/src/components/common/layouts/Header/index.tsx
+++ b/frontend/src/components/common/layouts/Header/index.tsx
@@ -65,7 +65,7 @@ export default function Header() {
               <>
                 <ThemeButton
                   onClick={toggleTheme}
-                  aria-label="테마 변경 버튼"
+                  aria-label="모바일 테마 변경"
                   $isDarkMode={isDarkMode}
                   style={{ position: 'fixed', right: '60px' }}
                 >
@@ -73,7 +73,7 @@ export default function Header() {
                 </ThemeButton>
                 <MobileMenuButton
                   onClick={() => setIsMenuOpen(true)}
-                  aria-label="메뉴 열기"
+                  aria-label="모바일 메뉴 열기"
                   style={{ position: 'fixed', right: '20px' }}
                 >
                   <RiMenuLine size={24} color={isDarkMode ? 'white' : 'grey'} />
@@ -92,7 +92,7 @@ export default function Header() {
                 )}
                 <MobileMenuButton
                   onClick={() => setIsMenuOpen(false)}
-                  aria-label="메뉴 닫기"
+                  aria-label="모바일 메뉴 닫기"
                   style={{ position: 'fixed', right: '20px' }}
                 >
                   <RiCloseLine size={26} color={isDarkMode ? 'white' : 'grey'} />

--- a/frontend/src/components/common/modals/LoginModal.tsx
+++ b/frontend/src/components/common/modals/LoginModal.tsx
@@ -57,7 +57,7 @@ export default function LoginModal({
         ReactDOM.createPortal(
           <ModalOverlay>
             <ModalContainer>
-              <CloseButton aria-label="close_btn" onClick={closeModal}>
+              <CloseButton aria-label="로그인 창닫기" onClick={closeModal}>
                 X
               </CloseButton>
               <TitleWrapper>
@@ -68,7 +68,7 @@ export default function LoginModal({
                   </Paragraph>
                 </IconBackground>
               </TitleWrapper>
-              <KakaoLoginButton aria-label="kakao_login_btn" onClick={handleKakaoLogin}>
+              <KakaoLoginButton aria-label="카카오 로그인" onClick={handleKakaoLogin}>
                 <FaComment />
                 <Text size="s" weight="normal">
                   카카오 로그인

--- a/frontend/src/components/common/modals/ResearchModal.tsx
+++ b/frontend/src/components/common/modals/ResearchModal.tsx
@@ -41,7 +41,7 @@ export default function ResearchModal() {
 
   return (
     <ModalContainer>
-      <CloseButton aria-label="close_btn" onClick={handleClose}>
+      <CloseButton aria-label="설문조사 닫기" onClick={handleClose}>
         X
       </CloseButton>
       <ContentWrapper>
@@ -59,7 +59,7 @@ export default function ResearchModal() {
           </IconBackground>
         </IconWrapper>
         <ButtonWrapper>
-          <SubmitButton aria-label="submit_btn" onClick={handleSurvey}>
+          <SubmitButton aria-label="의견 남기러 가기" onClick={handleSurvey}>
             의견 남기러 가기
           </SubmitButton>
         </ButtonWrapper>

--- a/frontend/src/pages/Choice/index.tsx
+++ b/frontend/src/pages/Choice/index.tsx
@@ -132,11 +132,11 @@ export default function ChoicePage() {
         itemsPerPage={pageableData?.pageable.pageSize}
       />
       <ButtonWrapper>
-        <Button aria-label="skip_btn" variant="white" style={buttonStyle} onClick={handleSkip}>
+        <Button aria-label="건너뛰기" variant="white" style={buttonStyle} onClick={handleSkip}>
           건너뛰기
         </Button>
         <Button
-          aria-label="start_btn"
+          aria-label="시작하기"
           variant="mint"
           style={{
             ...buttonStyle,

--- a/frontend/src/pages/Detail/index.tsx
+++ b/frontend/src/pages/Detail/index.tsx
@@ -113,11 +113,11 @@ export default function DetailPage() {
         <GradientOverlay />
         {infoData?.videos && infoData.videos.length > 1 && (
           <>
-            <PrevBtn aria-label="prev_btn" onClick={handleBtnPrevClick} disabled={currentVideoIndex === 0}>
+            <PrevBtn aria-label="썸네일 왼쪽" onClick={handleBtnPrevClick} disabled={currentVideoIndex === 0}>
               <GrPrevious size={40} color="white" />
             </PrevBtn>
             <NextBtn
-              aria-label="next_btn"
+              aria-label="썸네일 오른쪽"
               onClick={handleBtnNextClick}
               disabled={currentVideoIndex === infoData.videos.length - 1}
             >
@@ -136,7 +136,7 @@ export default function DetailPage() {
               <LikeContainer>
                 <LikeIcon
                   role="button"
-                  aria-label="like_btn"
+                  aria-label="디테일 좋아요"
                   onClick={(e: React.MouseEvent<HTMLDivElement>) => handleLikeClick(e)}
                 >
                   {isLike ? (
@@ -157,7 +157,7 @@ export default function DetailPage() {
               방문할래요
             </StyledButton> */}
             <StyledButton
-              aria-label="youtube_btn"
+              aria-label="영상보기"
               variant="outline"
               onClick={() => {
                 window.open(currentVideoUrl, '_blank');
@@ -170,7 +170,9 @@ export default function DetailPage() {
         </TitleContainer>
       </ImageContainer>
       <TapContainer>
-        <Tap aria-label="info_tap" /* $active={activeTab === 'info'} onClick={() => setActiveTab('info')} */>정보</Tap>
+        <Tap aria-label="디테일 정보탭" /* $active={activeTab === 'info'} onClick={() => setActiveTab('info')} */>
+          정보
+        </Tap>
         {/* <Tap aria-label="review_tap" $active={activeTab === 'review'} onClick={() => setActiveTab('review')}>
           리뷰
         </Tap> */}

--- a/frontend/src/pages/InfluencerInfo/index.tsx
+++ b/frontend/src/pages/InfluencerInfo/index.tsx
@@ -116,7 +116,7 @@ export default function InfluencerInfoPage() {
           </Text>
         </TextInfo>
         <LikeIcon
-          aria-label="like_btn"
+          aria-label="인플루언서 전용 좋아요"
           role="button"
           onClick={(e: React.MouseEvent<HTMLDivElement>) => handleLikeClick(e)}
         >
@@ -128,10 +128,10 @@ export default function InfluencerInfoPage() {
         </LikeIcon>
       </InfluencerInfoSection>
       <TapContainer>
-        <Tap aria-label="spot_tap" $active={activeTab === 'video'} onClick={() => setActiveTab('video')}>
+        <Tap aria-label="인플루언서 전용 쿨그" $active={activeTab === 'video'} onClick={() => setActiveTab('video')}>
           쿨한 그곳
         </Tap>
-        <Tap aria-label="place_tap" $active={activeTab === 'map'} onClick={() => setActiveTab('map')}>
+        <Tap aria-label="인플루언서 전용 쿨플" $active={activeTab === 'map'} onClick={() => setActiveTab('map')}>
           쿨 플레이스
         </Tap>
       </TapContainer>
@@ -140,7 +140,7 @@ export default function InfluencerInfoPage() {
           <>
             <SortSection ref={dropdownRef}>
               <StyledButton
-                aria-label="sort_btn"
+                aria-label="인플루언서 전용 정렬"
                 variant="white"
                 size="small"
                 onClick={() => setShowSortOptions(!showSortOptions)}

--- a/frontend/src/pages/Map/index.tsx
+++ b/frontend/src/pages/Map/index.tsx
@@ -122,7 +122,7 @@ export default function MapPage() {
       <Wrapper>
         <FilterContainer>
           <MobileFilterContainer>
-            <FilterButtonContainer aria-label="filterbar_btn" onClick={() => setIsFilterBarOpened((prev) => !prev)}>
+            <FilterButtonContainer aria-label="모바일 지도 필터" onClick={() => setIsFilterBarOpened((prev) => !prev)}>
               필터
             </FilterButtonContainer>
             <MapSearchBar setIsChangedLocation={setIsChangedLocation} setSelectedPlaceName={setSelectedPlaceName} />

--- a/frontend/src/pages/My/index.tsx
+++ b/frontend/src/pages/My/index.tsx
@@ -75,7 +75,7 @@ export default function MyPage() {
               <Text size="xl" weight="bold" style={{ color: '#47c8d9' }}>
                 {userNickname?.nickname}
               </Text>
-              <CustomButton aria-label="rename_btn" onClick={() => setIsVisible(false)}>
+              <CustomButton aria-label="닉네임 수정" onClick={() => setIsVisible(false)}>
                 <MdOutlineDriveFileRenameOutline size={24} color="#47c8d9" />
               </CustomButton>
               님, 안녕하세요!
@@ -84,7 +84,7 @@ export default function MyPage() {
         ) : (
           <Form onSubmit={handleSubmit}>
             <Input type="text" value={nickname} onChange={(e) => setNickname(e.target.value)} />
-            <CustomButton aria-label="rename_btn" type="submit">
+            <CustomButton aria-label="닉네임 수정 완료" type="submit">
               <MdOutlineDriveFileRenameOutline size={24} color="#47c8d9" />
             </CustomButton>
           </Form>

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -24,7 +24,7 @@ export default function NotFound() {
           요청한 페이지가 존재하지 않거나 삭제되었어요.
         </Paragraph>
       </TextWrapper>
-      <StyledButton aria-label="home-btn" variant={buttonVariant} onClick={handleHome}>
+      <StyledButton aria-label="NotFound 홈으로" variant={buttonVariant} onClick={handleHome}>
         홈으로 이동하기
       </StyledButton>
     </Wrapper>

--- a/frontend/src/pages/Review/index.tsx
+++ b/frontend/src/pages/Review/index.tsx
@@ -56,7 +56,7 @@ export default function ReviewPage() {
             <p>리뷰가 성공적으로 등록되었습니다.</p>
           </CompletionMessage>
           <Link to="/">
-            <StyledButton variant="outline" size="small">
+            <StyledButton aria-label="리뷰완료 홈으로" variant="outline" size="small">
               홈으로 이동하기
             </StyledButton>
           </Link>

--- a/frontend/src/test/influencerPagination.test.tsx
+++ b/frontend/src/test/influencerPagination.test.tsx
@@ -159,7 +159,7 @@ describe('인플루언서 페이지 페이지네이션 기능 테스트', () => 
 
     expect(screen.getByText('Influencer 1')).toBeInTheDocument();
 
-    const nextPageButton = screen.getByRole('button', { name: 'page_number_2' });
+    const nextPageButton = screen.getByRole('button', { name: '2_페이지' });
     fireEvent.click(nextPageButton);
 
     expect(screen.getByText('Influencer 11')).toBeInTheDocument();


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 애널리틱스 제거, 태그 매니저 연결
- [x] aria-label 한글로 변경
---

### ✨ 참고 사항
- 로컬이든 어디든 버튼들 클릭 후, 애널리틱스 [실시간개요 - 이벤트 이름 별 이벤트 수] 에서 값 증가하는지 확인할 수 있음
- 알아보기 쉽게 label들 한글로 다 바꿔놨는데 이상한 거 있으면 고치면 될듯
- a 태그(홈 로고), svg를 감싼 button(테마 변경)은 인식 되도록 예외처리 해뒀는데, 몇몇 버튼들에서 인식 안될 수도 있음. 확인해보고 필요한 버튼이면 로직 추가 예정 ex) 로그인 전 인플루언서 아이템 좋아요..
- env 이름 `VITE_GOOGLE_ANALYTICS`에서 `VITE_GOOGLE_TAG`로 바꼈고 값은 디코로 보내줄게!
---

### ⏰ 현재 버그

---

### ✏ Git Close
