### PR TITLE
 [INPLACE-219] cool video 수정 및 eats/plays 분리

### DIFF
--- a/backend/src/main/java/team7/inplace/global/exception/code/VideoErrorCode.java
+++ b/backend/src/main/java/team7/inplace/global/exception/code/VideoErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum VideoErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "V001", "영상 정보를 찾을 수 없습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "V001", "영상 정보를 찾을 수 없습니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "V002", "요청한 카테고리가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/backend/src/main/java/team7/inplace/place/application/CategoryService.java
+++ b/backend/src/main/java/team7/inplace/place/application/CategoryService.java
@@ -1,0 +1,19 @@
+package team7.inplace.place.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team7.inplace.place.persistence.CategoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<Long> getParentCategoryIds() {
+        return categoryRepository.findParentCategoryIds();
+    }
+}
+

--- a/backend/src/main/java/team7/inplace/place/application/CategoryService.java
+++ b/backend/src/main/java/team7/inplace/place/application/CategoryService.java
@@ -12,6 +12,11 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
+    public Long getCategoryId(String categoryName) {
+        return categoryRepository.findCategoryIdByName(categoryName);
+    }
+
+    @Transactional(readOnly = true)
     public List<Long> getParentCategoryIds() {
         return categoryRepository.findParentCategoryIds();
     }

--- a/backend/src/main/java/team7/inplace/place/persistence/CategoryRepository.java
+++ b/backend/src/main/java/team7/inplace/place/persistence/CategoryRepository.java
@@ -1,8 +1,15 @@
 package team7.inplace.place.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import team7.inplace.place.domain.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    @Query("SELECT c.id FROM categories c WHERE c.name = :categoryName")
+    Long findCategoryIdByName(String categoryName);
+
+    @Query("select c.id from categories c where c.parentId is null")
+    List<Long> findParentCategoryIds();
 }

--- a/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import team7.inplace.global.annotation.Facade;
 import team7.inplace.influencer.application.InfluencerService;
+import team7.inplace.place.application.CategoryService;
 import team7.inplace.place.application.PlaceService;
 import team7.inplace.security.util.AuthorizationUtil;
 import team7.inplace.video.application.command.VideoCommand;
@@ -21,6 +22,7 @@ public class VideoFacade {
     private final VideoService videoService;
     private final InfluencerService influencerService;
     private final PlaceService placeService;
+    private final CategoryService categoryService;
 
     @Transactional
     public void createMediumVideos(
@@ -57,4 +59,11 @@ public class VideoFacade {
     public Page<VideoQueryResult.SimpleVideo> getVideoWithNoPlace(Pageable pageable) {
         return videoService.getVideoWithNoPlace(pageable);
     }
+
+    @Transactional
+    public void updateCoolVideos() {
+        List<Long> parentCategoryIds = categoryService.getParentCategoryIds();
+        videoService.updateCoolVideos(parentCategoryIds);
+    }
+
 }

--- a/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoFacade.java
@@ -60,6 +60,11 @@ public class VideoFacade {
         return videoService.getVideoWithNoPlace(pageable);
     }
 
+    @Transactional(readOnly = true)
+    public Long getCategoryId(String categoryName) {
+        return categoryService.getCategoryId(categoryName);
+    }
+
     @Transactional
     public void updateCoolVideos() {
         List<Long> parentCategoryIds = categoryService.getParentCategoryIds();

--- a/backend/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoService.java
@@ -62,8 +62,8 @@ public class VideoService {
     }
 
     @Transactional(readOnly = true)
-    public List<VideoQueryResult.DetailedVideo> getCoolVideo() {
-        var top10Videos = coolVideoRepository.findAll();
+    public List<VideoQueryResult.DetailedVideo> getCoolVideo(Long parentCategoryId) {
+        var top10Videos = coolVideoRepository.findByPlaceCategoryParentId(parentCategoryId);
 
         return top10Videos.stream().map(DetailedVideo::from).toList();
     }

--- a/backend/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoService.java
@@ -1,5 +1,6 @@
 package team7.inplace.video.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -122,9 +123,14 @@ public class VideoService {
     }
 
     @Transactional
-    public void updateCoolVideos() {
-        // 인기순 top 10 video 가져오기
-        List<DetailedVideo> coolVideos = videoReadRepository.findTop10ByViewCountIncrement();
+    public void updateCoolVideos(List<Long> parentCategoryIds) {
+        List<DetailedVideo> coolVideos = new ArrayList<>();
+
+        // 상위 카테고리별 인기순 top 10 video 가져오기
+        for (Long parentCategoryId : parentCategoryIds) {
+            List<DetailedVideo> top10 = videoReadRepository.findTop10ByViewCountIncrement(parentCategoryId);
+            coolVideos.addAll(top10);
+        }
 
         // coolVideo table 업데이트하기
         coolVideoRepository.deleteAll();

--- a/backend/src/main/java/team7/inplace/video/domain/CoolVideo.java
+++ b/backend/src/main/java/team7/inplace/video/domain/CoolVideo.java
@@ -35,6 +35,9 @@ public class CoolVideo {
     @Column(name = "place_category")
     private String placeCategory;
 
+    @Column(name = "place_category_parent_id")
+    private Long placeCategoryParentId;
+
     @Column(name = "place_name")
     private String placeName;
 
@@ -54,6 +57,7 @@ public class CoolVideo {
         Long placeId,
         String placeName,
         String placeCategory,
+        Long placeCategoryParentId,
         String address1,
         String address2,
         String address3
@@ -64,6 +68,7 @@ public class CoolVideo {
         this.placeId = placeId;
         this.placeName = placeName;
         this.placeCategory = placeCategory;
+        this.placeCategoryParentId = placeCategoryParentId;
         this.address1 = address1;
         this.address2 = address2;
         this.address3 = address3;
@@ -76,6 +81,7 @@ public class CoolVideo {
         Long placeId,
         String placeName,
         String placeCategory,
+        Long placeCategoryParentId,
         String address1,
         String address2,
         String address3
@@ -87,6 +93,7 @@ public class CoolVideo {
             placeId,
             placeName,
             placeCategory,
+            placeCategoryParentId,
             address1,
             address2,
             address3

--- a/backend/src/main/java/team7/inplace/video/domain/ParentCategory.java
+++ b/backend/src/main/java/team7/inplace/video/domain/ParentCategory.java
@@ -1,0 +1,25 @@
+package team7.inplace.video.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import team7.inplace.global.exception.InplaceException;
+import team7.inplace.global.exception.code.VideoErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParentCategory {
+    EATS("맛집"),
+    PLAYS("놀거리");
+
+    private final String parentCategory;
+
+    public static ParentCategory from(String categoryName) {
+        for (ParentCategory category : values()) {
+            if (category.name().equalsIgnoreCase(categoryName)) {
+                return category;
+            }
+        }
+        throw InplaceException.of(VideoErrorCode.INVALID_CATEGORY);
+    }
+
+}

--- a/backend/src/main/java/team7/inplace/video/persistence/CoolVideoRepository.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/CoolVideoRepository.java
@@ -1,8 +1,10 @@
 package team7.inplace.video.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team7.inplace.video.domain.CoolVideo;
 
 public interface CoolVideoRepository extends JpaRepository<CoolVideo, Long> {
 
+    List<CoolVideo> findByPlaceCategoryParentId(Long parentCategoryId);
 }

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
@@ -17,7 +17,7 @@ public interface VideoReadRepository {
             Pageable pageable
     );
 
-    List<VideoQueryResult.DetailedVideo> findTop10ByViewCountIncrement();
+    List<VideoQueryResult.DetailedVideo> findTop10ByViewCountIncrement(Long parentCategoryIds);
 
     List<VideoQueryResult.DetailedVideo> findTop10ByLatestUploadDate();
 

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepository.java
@@ -17,7 +17,7 @@ public interface VideoReadRepository {
             Pageable pageable
     );
 
-    List<VideoQueryResult.DetailedVideo> findTop10ByViewCountIncrement(Long parentCategoryIds);
+    List<VideoQueryResult.DetailedVideo> findTop10ByViewCountIncrement(Long parentCategoryId);
 
     List<VideoQueryResult.DetailedVideo> findTop10ByLatestUploadDate();
 

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepositoryImpl.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoReadRepositoryImpl.java
@@ -69,9 +69,12 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
     }
 
     @Override
-    public List<DetailedVideo> findTop10ByViewCountIncrement() {
+    public List<DetailedVideo> findTop10ByViewCountIncrement(Long parentCategoryId) {
         return buildDetailedVideoQuery()
-            .where(commonWhere().and(QPlaceVideo.placeVideo.isNotNull()))
+            .where(commonWhere()
+                .and(QPlaceVideo.placeVideo.isNotNull())
+                .and(QCategory.category.parentId.eq(parentCategoryId)) // 상위 카테고리 ID로 필터링
+            )
             .orderBy(QVideo.video.view.viewCountIncrease.desc())
             .limit(10)
             .fetch();
@@ -201,6 +204,7 @@ public class VideoReadRepositoryImpl implements VideoReadRepository {
                 QPlace.place.id,
                 QPlace.place.name,
                 QCategory.category.name,
+                QCategory.category.parentId,
                 QPlace.place.address.address1,
                 QPlace.place.address.address2,
                 QPlace.place.address.address3

--- a/backend/src/main/java/team7/inplace/video/persistence/dto/VideoQueryResult.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/dto/VideoQueryResult.java
@@ -1,6 +1,7 @@
 package team7.inplace.video.persistence.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import org.springframework.lang.Nullable;
 import team7.inplace.video.domain.CoolVideo;
 import team7.inplace.video.domain.RecentVideo;
 
@@ -31,6 +32,7 @@ public class VideoQueryResult {
         Long placeId,
         String placeName,
         String placeCategory,
+        @Nullable Long placeCategoryParentId,
         String address1,
         String address2,
         String address3
@@ -48,6 +50,7 @@ public class VideoQueryResult {
                 coolVideo.getPlaceId(),
                 coolVideo.getPlaceName(),
                 coolVideo.getPlaceCategory(),
+                coolVideo.getPlaceCategoryParentId(),
                 coolVideo.getAddress1(),
                 coolVideo.getAddress2(),
                 coolVideo.getAddress3()
@@ -62,6 +65,7 @@ public class VideoQueryResult {
                 recentVideo.getPlaceId(),
                 recentVideo.getPlaceName(),
                 recentVideo.getPlaceCategory(),
+                null,
                 recentVideo.getAddress1(),
                 recentVideo.getAddress2(),
                 recentVideo.getAddress3()
@@ -74,7 +78,7 @@ public class VideoQueryResult {
 
         public CoolVideo toCoolVideo() {
             return CoolVideo.from(videoId, videoUUID, influencerName, placeId, placeName,
-                placeCategory, address1, address2, address3);
+                placeCategory, placeCategoryParentId, address1, address2, address3);
         }
 
         public RecentVideo toRecentVideo() {

--- a/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -89,7 +89,7 @@ public class VideoController implements VideoControllerApiSpec {
     @GetMapping("/update")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> updateMainVideos() {
-        videoService.updateCoolVideos();
+        videoFacade.updateCoolVideos();
         videoService.updateRecentVideos();
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team7.inplace.video.application.VideoFacade;
 import team7.inplace.video.application.VideoService;
+import team7.inplace.video.domain.ParentCategory;
 import team7.inplace.video.presentation.dto.VideoResponse;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
 
@@ -50,9 +51,12 @@ public class VideoController implements VideoControllerApiSpec {
     }
 
     @Override
-    @GetMapping("/cool")
-    public ResponseEntity<List<VideoResponse.Detail>> readByCool() {
-        var videoResponses = videoService.getCoolVideo()
+    @GetMapping("/cool/{category}")
+    public ResponseEntity<List<VideoResponse.Detail>> readByCool(@PathVariable String category) {
+        var parentCategory = ParentCategory.from(category);
+        var parentCategoryId = videoFacade.getCategoryId(parentCategory.getParentCategory());
+
+        var videoResponses = videoService.getCoolVideo(parentCategoryId)
             .stream().map(VideoResponse.Detail::from).toList();
         return new ResponseEntity<>(videoResponses, HttpStatus.OK);
     }

--- a/backend/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
@@ -33,7 +33,7 @@ public interface VideoControllerApiSpec {
         summary = "쿨한 그 곳",
         description = "조회수 증가량을 기준으로 내림차순 정렬한 Video 정보를 조회합니다."
     )
-    ResponseEntity<List<VideoResponse.Detail>> readByCool();
+    ResponseEntity<List<VideoResponse.Detail>> readByCool(@PathVariable String category);
 
     @Operation(
         summary = "내 인플루언서의 비디오 반환",

--- a/backend/src/test/java/team7/inplace/video/application/VideoServiceTest.java
+++ b/backend/src/test/java/team7/inplace/video/application/VideoServiceTest.java
@@ -59,11 +59,12 @@ class VideoServiceTest {
                 tuple("CoolVideo9", "CoolInfluencer9", "CoolPlace9"),
                 tuple("CoolVideo10", "CoolInfluencer10", "CoolPlace10")
             );
+        var parentCategoryIds = List.of(1L);
+
         //when
+        videoService.updateCoolVideos(parentCategoryIds);
 
-        videoService.updateCoolVideos();
         //then
-
         List<CoolVideo> updatedCoolVideos = coolVideoRepository.findAll();
         assertThat(updatedCoolVideos)
             .hasSize(10)
@@ -73,13 +74,13 @@ class VideoServiceTest {
                 tuple("Video19", "influencer5", "testPlace19"),
                 tuple("Video18", "influencer5", "testPlace18"),
                 tuple("Video17", "influencer5", "testPlace17"),
-                tuple("Video16", "influencer4", "testPlace16"),
                 tuple("Video15", "influencer4", "testPlace15"),
                 tuple("Video14", "influencer4", "testPlace14"),
                 tuple("Video13", "influencer4", "testPlace13"),
                 tuple("Video12", "influencer3", "testPlace12"),
-                tuple("Video11", "influencer3", "testPlace11")
-            );
+                tuple("Video10", "influencer3", "testPlace10"),
+                tuple("Video9", "influencer3", "testPlace9")
+                );
     }
 
     @Test
@@ -102,11 +103,11 @@ class VideoServiceTest {
                 tuple("RecentVideo9", "RecentInfluencer9", "RecentPlace9"),
                 tuple("RecentVideo10", "RecentInfluencer10", "RecentPlace10")
             );
+
         //when
-
         videoService.updateRecentVideos();
-        //then
 
+        //then
         List<RecentVideo> updatedRecentVideos = recentVideoRepository.findAll();
         assertThat(updatedRecentVideos)
             .hasSize(10)

--- a/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
+++ b/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
@@ -63,14 +63,15 @@ public class VideoReadRepositoryTest {
     }
 
     @Test
-    @DisplayName("비디오 조회 테스트 - 조회수 증가량 순으로 비디오 10개 조회")
+    @DisplayName("비디오 조회 테스트 - 조회수 증가량 순으로 비디오 10개 조회 (상위 카테고리 적용)")
     void findVideo_ViewCountDesc() {
         // given
         final int expectedTotalContent = 10;
-        final List<Long> expectedVideoIds = List.of(20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L);
+        final List<Long> expectedVideoIds = List.of(20L, 19L, 18L, 17L, 15L, 14L, 13L, 12L, 10L, 9L);
+        Long parentCategoryId = 1L;
 
         // when
-        List<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findTop10ByViewCountIncrement();
+        List<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findTop10ByViewCountIncrement(parentCategoryId);
 
         // then
         assertThat(videos.size()).isEqualTo(expectedTotalContent);

--- a/backend/src/test/resources/sql/test-cool-recent-video.sql
+++ b/backend/src/test/resources/sql/test-cool-recent-video.sql
@@ -1,14 +1,14 @@
-INSERT INTO cool_videos (id, video_id, uuid, influencer_name, place_id, place_name, place_category)
-VALUES (1, 1, 'CoolVideo1', 'CoolInfluencer1', 101, 'CoolPlace1', 'RESTAURANT'),
-       (2, 2, 'CoolVideo2', 'CoolInfluencer2', 102, 'CoolPlace2', 'CAFE'),
-       (3, 3, 'CoolVideo3', 'CoolInfluencer3', 103, 'CoolPlace3', 'JAPANESE'),
-       (4, 4, 'CoolVideo4', 'CoolInfluencer4', 104, 'CoolPlace4', 'KOREAN'),
-       (5, 5, 'CoolVideo5', 'CoolInfluencer5', 105, 'CoolPlace5', 'NONE'),
-       (6, 6, 'CoolVideo6', 'CoolInfluencer6', 106, 'CoolPlace6', 'WESTERN'),
-       (7, 7, 'CoolVideo7', 'CoolInfluencer7', 107, 'CoolPlace7', 'RESTAURANT'),
-       (8, 8, 'CoolVideo8', 'CoolInfluencer8', 108, 'CoolPlace8', 'CAFE'),
-       (9, 9, 'CoolVideo9', 'CoolInfluencer9', 109, 'CoolPlace9', 'JAPANESE'),
-       (10, 10, 'CoolVideo10', 'CoolInfluencer10', 110, 'CoolPlace10', 'KOREAN');
+INSERT INTO cool_videos (id, video_id, uuid, influencer_name, place_id, place_name, place_category, place_category_parent_id)
+VALUES (1, 1, 'CoolVideo1', 'CoolInfluencer1', 101, 'CoolPlace1', 'RESTAURANT', 1L),
+       (2, 2, 'CoolVideo2', 'CoolInfluencer2', 102, 'CoolPlace2', 'CAFE',1L),
+       (3, 3, 'CoolVideo3', 'CoolInfluencer3', 103, 'CoolPlace3', 'JAPANESE',1L),
+       (4, 4, 'CoolVideo4', 'CoolInfluencer4', 104, 'CoolPlace4', 'KOREAN',1L),
+       (5, 5, 'CoolVideo5', 'CoolInfluencer5', 105, 'CoolPlace5', 'NONE',1L),
+       (6, 6, 'CoolVideo6', 'CoolInfluencer6', 106, 'CoolPlace6', 'WESTERN',1L),
+       (7, 7, 'CoolVideo7', 'CoolInfluencer7', 107, 'CoolPlace7', 'RESTAURANT',1L),
+       (8, 8, 'CoolVideo8', 'CoolInfluencer8', 108, 'CoolPlace8', 'CAFE',1L),
+       (9, 9, 'CoolVideo9', 'CoolInfluencer9', 109, 'CoolPlace9', 'JAPANESE',1L),
+       (10, 10, 'CoolVideo10', 'CoolInfluencer10', 110, 'CoolPlace10', 'KOREAN',1L);
 
 INSERT INTO categories(id, name, parent_id)
 VALUES (1, '맛집', null),
@@ -85,3 +85,26 @@ VALUES (1, 1, 'RecentVideo1', 'RecentInfluencer1', 101, 'RecentPlace1', 'RESTAUR
        (8, 8, 'RecentVideo8', 'RecentInfluencer8', 108, 'RecentPlace8', 'CAFE'),
        (9, 9, 'RecentVideo9', 'RecentInfluencer9', 109, 'RecentPlace9', 'JAPANESE'),
        (10, 10, 'RecentVideo10', 'RecentInfluencer10', 110, 'RecentPlace10', 'KOREAN');
+
+
+INSERT INTO place_videos (id, place_id, video_id)
+VALUES (1, 1, 1),
+       (2, 2, 2),
+       (3, 3, 3),
+       (4, 4, 4),
+       (5, 5, 5),
+       (6, 6, 6),
+       (7, 7, 7),
+       (8, 8, 8),
+       (9, 9, 9),
+       (10, 10, 10),
+       (11, 11, 11),
+       (12, 12, 12),
+       (13, 13, 13),
+       (14, 14, 14),
+       (15, 15, 15),
+       (16, 16, 16),
+       (17, 17, 17),
+       (18, 18, 18),
+       (19, 19, 19),
+       (20, 20, 20);


### PR DESCRIPTION
### ✨ 작업 내용
- CoolVideo, DetailedVideo에 상위 카테고리 필드 추가
- videos/cool/plays, videos/cool/eats 로 분리
---

### ✨ 참고 사항
- cool video 업데이트할 때 
  `CategoryService(상위 카테고리들 id 조회) -> VideoFacade -> VideoService(상위 카테고리별 인기순 조회)`
  이렇게 되는데 VideoService에서 for문으로 카테고리별 조회하도록 해서 상위 카테고리 수가 많아지면 수정 필요할 거 같습니다.. 
  근데 안많아질 거 같아서 for문으로 했는데, 어떻게 생각하시나요????
- cool/plays, cool/eats 요청 처리할때 
  상위 카테고리 목록을 enum으로 만들어두고 했습니다. 더 좋은 방법 있을까요 뭔가 로직이 최선이 아닌 느낌 .......
 

---

### ⏰ 현재 버그

---

### ✏ Git Close
