### PR TITLE
[INPLACE-242] 구글 태그 매니저에 먼저 애널리틱스 이벤트가 전송되도록 변경

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,9 @@
     <title>인플레이스</title>
     <meta name="description" content="긴 영상은 필요 없어요 인플루언서가 다녀간 쿨플, 한눈에 쏙!" />
 
+    <script>
+      window.dataLayer = window.dataLayer || [];
+    </script>
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {

--- a/frontend/src/provider/ABTest/index.tsx
+++ b/frontend/src/provider/ABTest/index.tsx
@@ -50,14 +50,17 @@ export default function ABTestProvider({
     if (!initialized || Object.keys(testGroups).length === 0) {
       return;
     }
-    if (typeof window !== 'undefined' && window.gtag) {
+    if (typeof window !== 'undefined') {
       // GA4에 사용자 속성 설정
       const userProperties: Record<string, string> = {};
       Object.entries(testGroups).forEach(([testName, group]) => {
         userProperties[`ab_test_${testName}`] = group;
       });
+      window.dataLayer.push({
+        event: 'set_user_properties',
+        user_properties: userProperties,
+      });
 
-      window.gtag('set', 'user_properties', userProperties);
       // GA4에 이벤트 전송
       Object.entries(testGroups).forEach(([testName, group]) => {
         sendGAEvent('ab_test_count', {

--- a/frontend/src/test/searchData.test.tsx
+++ b/frontend/src/test/searchData.test.tsx
@@ -7,6 +7,11 @@ import SearchPage from '@/pages/Search';
 import { AuthContext } from '@/provider/Auth';
 import ABTestProvider from '@/provider/ABTest';
 
+Object.defineProperty(window, 'dataLayer', {
+  writable: true,
+  value: [],
+});
+
 jest.mock('@/api/hooks/useGetSearchComplete');
 (completeApi.useGetSearchComplete as jest.Mock).mockReturnValue({
   data: [

--- a/frontend/src/utils/test/googleTestUtils.tsx
+++ b/frontend/src/utils/test/googleTestUtils.tsx
@@ -21,10 +21,18 @@ export const setCookie = (name: string, value: string, days: number): void => {
   document.cookie = `${name}=${value};${expires};path=/`;
 };
 
+interface DataLayerEvent {
+  event: string;
+  [key: string]: unknown;
+}
+
 // GA4 이벤트 전송 함수
 export const sendGAEvent = (eventName: string, parameters: Record<string, unknown> = {}): void => {
-  if (typeof window !== 'undefined' && window.gtag) {
-    window.gtag('event', eventName, parameters);
+  if (typeof window !== 'undefined') {
+    window.dataLayer.push({
+      event: eventName,
+      ...parameters,
+    });
   } else {
     console.warn('Google Analytics not initialized');
   }
@@ -32,6 +40,7 @@ export const sendGAEvent = (eventName: string, parameters: Record<string, unknow
 
 declare global {
   interface Window {
-    gtag: (command: string, action: string, params?: Record<string, unknown>) => void;
+    dataLayer: DataLayerEvent[];
+    gtag?: (command: string, action: string, params?: Record<string, unknown>) => void;
   }
 }


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 구글 태그 매니저에 먼저 애널리틱스 이벤트가 전송되도록 변경
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
