### PR TITLE
[INPLACE-251] 장소의 주변 장소 반환 

### DIFF
--- a/backend/src/main/java/team7/inplace/place/application/dto/PlaceInfo.java
+++ b/backend/src/main/java/team7/inplace/place/application/dto/PlaceInfo.java
@@ -14,18 +14,23 @@ public class PlaceInfo {
         PlaceQueryResult.DetailedPlace place,
         GooglePlaceClientResponse.Place googlePlace,
         List<VideoQueryResult.SimpleVideo> videos,
-        ReviewQueryResult.LikeRate reviewLikeRate
+        ReviewQueryResult.LikeRate reviewLikeRate,
+        List<VideoQueryResult.DetailedVideo> surroundVideos
     ) {
 
         public static Detail of(
-            PlaceQueryResult.DetailedPlace place, GooglePlaceClientResponse.Place googlePlace,
-            List<VideoQueryResult.SimpleVideo> videos, ReviewQueryResult.LikeRate reviewLikeRate
+            PlaceQueryResult.DetailedPlace place,
+            GooglePlaceClientResponse.Place googlePlace,
+            List<VideoQueryResult.SimpleVideo> videos,
+            ReviewQueryResult.LikeRate reviewLikeRate,
+            List<VideoQueryResult.DetailedVideo> surroundVideos
         ) {
             return new Detail(
                 place,
                 googlePlace,
                 videos,
-                reviewLikeRate
+                reviewLikeRate,
+                surroundVideos
             );
         }
     }

--- a/backend/src/main/java/team7/inplace/place/presentation/dto/PlacesResponse.java
+++ b/backend/src/main/java/team7/inplace/place/presentation/dto/PlacesResponse.java
@@ -71,6 +71,7 @@ public class PlacesResponse {
         Double latitude,
         PlacesResponse.Facility facility,
         List<PlacesResponse.Video> videos,
+        List<PlacesResponse.SurroundVideo> surroundVideos,
         List<PlacesResponse.GoogleReview> googleReviews,
         Double rating,
         String kakaoPlaceUrl,
@@ -106,6 +107,9 @@ public class PlacesResponse {
                 null,
                 place.videos().stream()
                     .map(PlacesResponse.Video::from)
+                    .toList(),
+                place.surroundVideos().stream()
+                    .map(PlacesResponse.SurroundVideo::from)
                     .toList(),
                 List.of(),
                 null,
@@ -145,6 +149,9 @@ public class PlacesResponse {
                 place.videos().stream()
                     .map(PlacesResponse.Video::from)
                     .toList(),
+                place.surroundVideos().stream()
+                    .map(PlacesResponse.SurroundVideo::from)
+                    .toList(),
                 place.googlePlace().reviews().orElse(List.of())
                     .stream()
                     .map(PlacesResponse.GoogleReview::from)
@@ -178,7 +185,6 @@ public class PlacesResponse {
         String address2,
         String address3
     ) {
-
     }
 
     @JsonInclude(Include.NON_NULL)
@@ -262,6 +268,39 @@ public class PlacesResponse {
             return new PlacesResponse.Video(video.videoUrl(), video.influencerName());
         }
     }
+
+    public record SurroundVideo(
+        Long videoId,
+        String influencerName,
+        String videoUrl,
+        PlacesResponse.PlaceDetail place
+    ) {
+        public static SurroundVideo from(VideoQueryResult.DetailedVideo videoInfo) {
+            var place = new PlacesResponse.PlaceDetail(
+                videoInfo.placeId(),
+                videoInfo.placeName(),
+                new PlacesResponse.Address(
+                    videoInfo.address1(),
+                    videoInfo.address2(),
+                    videoInfo.address3()
+                )
+            );
+            return new SurroundVideo(
+                videoInfo.videoId(),
+                videoInfo.influencerName(),
+                videoInfo.videoUrl(),
+                place
+            );
+        }
+    }
+
+    public record PlaceDetail(
+        Long placeId,
+        String placeName,
+        PlacesResponse.Address address
+    ) {
+    }
+
 
     public record Marker(
         Long placeId,

--- a/backend/src/main/java/team7/inplace/place/presentation/dto/PlacesResponse.java
+++ b/backend/src/main/java/team7/inplace/place/presentation/dto/PlacesResponse.java
@@ -363,7 +363,7 @@ public class PlacesResponse {
             return new PlacesResponse.Admin(
                 simple.place().placeId(),
                 simple.place().placeName(),
-                simple.place().category().toString(),
+                simple.place().category(),
                 simple.place().address1() + " " + simple.place().address2() + " " + simple.place()
                     .address3(),
                 simple.place().longitude(),

--- a/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/dto/VideoResponse.java
@@ -65,7 +65,6 @@ public class VideoResponse {
         String address2,
         String address3
     ) {
-
     }
 
     public record Admin(

--- a/backend/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
+++ b/backend/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
@@ -1,21 +1,21 @@
 package team7.inplace.video.presentation.dto;
 
 public record VideoSearchParams(
-        String topLeftLongitude,
-        String topLeftLatitude,
-        String bottomRightLongitude,
-        String bottomRightLatitude,
-        String longitude,
-        String latitude
+    String topLeftLongitude,
+    String topLeftLatitude,
+    String bottomRightLongitude,
+    String bottomRightLatitude,
+    String longitude,
+    String latitude
 ) {
     private VideoSearchParams(String longitude, String latitude) {
         this(
-                calculateTopLeftLongitude(longitude),   // topLeftLongitude
-                calculateTopLeftLatitude(latitude),     // topLeftLatitude
-                calculateBottomRightLongitude(longitude), // bottomRightLongitude
-                calculateBottomRightLatitude(latitude),   // bottomRightLatitude
-                longitude,
-                latitude
+            calculateTopLeftLongitude(longitude),   // topLeftLongitude
+            calculateTopLeftLatitude(latitude),     // topLeftLatitude
+            calculateBottomRightLongitude(longitude), // bottomRightLongitude
+            calculateBottomRightLatitude(latitude),   // bottomRightLatitude
+            longitude,
+            latitude
         );
     }
 

--- a/backend/src/main/resources/static/js/video.js
+++ b/backend/src/main/resources/static/js/video.js
@@ -74,7 +74,7 @@ function addPlaceRow(place = null) {
 
   $('#place-register-tbody').append(rowHtml);
 
-  populateCategoryOptions(rowIdx, place?.category.name);
+  populateCategoryOptions(rowIdx, place?.category);
 }
 
 function populateCategoryOptions(rowIdx, selectedCategory = '') {

--- a/backend/src/main/resources/templates/admin/video.html
+++ b/backend/src/main/resources/templates/admin/video.html
@@ -82,7 +82,7 @@
 <div>
   <div>
     <!-- Previous -->
-    <a th:href="@{/admin/video(page=${videoPage.number - 1}, size=10, influencerId=${selectedInfluencerId})}"
+    <a th:href="@{/admin/video(page=${videoPage.number - 1}, size=10, influencerId=${selectedInfluencerId}, videoRegistration=${videoRegistration})}"
        th:if="${videoPage.hasPrevious()}">Previous</a>
 
     <!-- 페이지 정보 표시 -->
@@ -90,7 +90,7 @@
         th:text="${videoPage.totalPages}"></span></span>
 
     <!-- Next -->
-    <a th:href="@{/admin/video(page=${videoPage.number + 1}, size=10, influencerId=${selectedInfluencerId})}"
+    <a th:href="@{/admin/video(page=${videoPage.number + 1}, size=10, influencerId=${selectedInfluencerId}, videoRegistration=${videoRegistration})}"
        th:if="${videoPage.hasNext()}">Next</a>
   </div>
 </div>


### PR DESCRIPTION
### ✨ 작업 내용

- 장소 상세 조회 API의 반환 값에 주변 장소에 대한 비디오 정보를 추가했습니다
- '주변 장소 비디오' 의 반환 값은 메인 페이지 '내 주변 장소의 비디오'와 동일한 로직으로 가져옵니다
- 반환 값 역시 이와 동일합니다.

---

### ✨ 참고 사항

- 내 주변 장소에서 Page를 안써도 될 거 같은데, 사양 변경같은 문제로 안바꾸고 있는건가요? 

---

### ⏰ 현재 버그

---

### ✏ Git Close
