### PR TITLE
[INPLACE-243] 비디오 soft delete 및 인플루언서 숨김 반영하도록 수정

### DIFF
--- a/backend/src/main/java/team7/inplace/admin/crawling/application/YoutubeCrawlingService.java
+++ b/backend/src/main/java/team7/inplace/admin/crawling/application/YoutubeCrawlingService.java
@@ -45,7 +45,7 @@ public class YoutubeCrawlingService {
 
     @Transactional(readOnly = true)
     public List<ViewInfo> crawlingVideoView() {
-        var videos = videoRepository.findAll();
+        var videos = videoRepository.findAllByDeleteAtIsNull();
 
         var videoInfos = videos.stream().map(video -> {
             var videoId = video.getId();

--- a/backend/src/main/java/team7/inplace/global/baseEntity/BaseEntity.java
+++ b/backend/src/main/java/team7/inplace/global/baseEntity/BaseEntity.java
@@ -31,8 +31,8 @@ public abstract class BaseEntity {
 
     private LocalDateTime deleteAt;
 
-    public void deleteSoftly(LocalDateTime deleteAt) {
-        this.deleteAt = deleteAt;
+    public void deleteSoftly() {
+        this.deleteAt = LocalDateTime.now();
     }
 
     public boolean isSoftDeleted() {

--- a/backend/src/main/java/team7/inplace/influencer/persistence/InfluencerReadRepositoryImpl.java
+++ b/backend/src/main/java/team7/inplace/influencer/persistence/InfluencerReadRepositoryImpl.java
@@ -89,7 +89,8 @@ public class InfluencerReadRepositoryImpl implements InfluencerReadRepository {
             .leftJoin(QPlaceVideo.placeVideo).on(QVideo.video.id.eq(QPlaceVideo.placeVideo.videoId))
             .where(QPlaceVideo.placeVideo.placeId.eq(placeId)
                 .and(QPlaceVideo.placeVideo.isNotNull())
-                .and(QVideo.video.deleteAt.isNull()))
+                .and(QVideo.video.deleteAt.isNull())
+                .and(QInfluencer.influencer.hidden.isFalse()))
             .fetch();
     }
 
@@ -98,14 +99,15 @@ public class InfluencerReadRepositoryImpl implements InfluencerReadRepository {
         var totalCount = queryFactory
             .select(count(QInfluencer.influencer.id))
             .from(QInfluencer.influencer)
-            .where(QInfluencer.influencer.deleteAt.isNull())
+            .where(QInfluencer.influencer.deleteAt.isNull()
+                .and(QInfluencer.influencer.hidden.isFalse()))
             .fetchOne();
 
         if (totalCount == null || totalCount == 0) {
             return Page.empty(pageable);
         }
 
-        var influeencers = queryFactory
+        var influencers = queryFactory
             .select(new QInfluencerQueryResult_Simple(
                 QInfluencer.influencer.id,
                 QInfluencer.influencer.name,
@@ -121,7 +123,8 @@ public class InfluencerReadRepositoryImpl implements InfluencerReadRepository {
                         Expressions.FALSE :
                         QLikedInfluencer.likedInfluencer.userId.eq(userId)
                 ))
-            .where(QInfluencer.influencer.deleteAt.isNull())
+            .where(QInfluencer.influencer.deleteAt.isNull()
+                .and(QInfluencer.influencer.hidden.isFalse()))
             .orderBy(QLikedInfluencer.likedInfluencer.isLiked.desc(),
                 QInfluencer.influencer.id.asc()
             )
@@ -129,7 +132,7 @@ public class InfluencerReadRepositoryImpl implements InfluencerReadRepository {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return new PageImpl<>(influeencers, pageable, totalCount);
+        return new PageImpl<>(influencers, pageable, totalCount);
     }
 
 }

--- a/backend/src/main/java/team7/inplace/influencer/persistence/InfluencerRepository.java
+++ b/backend/src/main/java/team7/inplace/influencer/persistence/InfluencerRepository.java
@@ -9,13 +9,13 @@ import team7.inplace.influencer.domain.Influencer;
 public interface InfluencerRepository extends JpaRepository<Influencer, Long> {
 
     @Override
-    @Query("SELECT i FROM Influencer i WHERE i.deleteAt IS NULL AND i.id IN :longs")
+    @Query("SELECT i FROM Influencer i WHERE i.deleteAt IS NULL AND i.hidden = false AND i.id IN :longs")
     List<Influencer> findAllById(Iterable<Long> longs);
 
-    @Query("SELECT i FROM Influencer i WHERE i.deleteAt IS NULL AND i.name IN :names")
+    @Query("SELECT i FROM Influencer i WHERE i.deleteAt IS NULL AND i.hidden = false AND i.name IN :names")
     List<Influencer> findByNameIn(List<String> names);
 
-    @Query("SELECT i.name FROM Influencer i WHERE i.deleteAt IS NULL")
+    @Query("SELECT i.name FROM Influencer i WHERE i.deleteAt IS NULL AND i.hidden = false")
     List<String> findAllInfluencerNames();
 
     @Query("SELECT i.id FROM Influencer i WHERE i.name = :name")

--- a/backend/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/backend/src/main/java/team7/inplace/video/application/VideoService.java
@@ -126,7 +126,10 @@ public class VideoService {
 
     @Transactional
     public void deleteVideo(Long videoId) {
-        videoRepository.deleteById(videoId);
+        Video video = videoRepository.findById(videoId)
+            .orElseThrow(() -> InplaceException.of(VideoErrorCode.NOT_FOUND));
+
+        video.deleteSoftly();
     }
 
     @Transactional

--- a/backend/src/main/java/team7/inplace/video/persistence/VideoRepository.java
+++ b/backend/src/main/java/team7/inplace/video/persistence/VideoRepository.java
@@ -1,5 +1,6 @@
 package team7.inplace.video.persistence;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,6 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
         countQuery = "SELECT COUNT(v) FROM Video v where v.placeId IS NULL"
     )
     Page<Video> findAllByPlaceIdIsNull(Pageable pageable);
+
+    List<Video> findAllByDeleteAtIsNull();
 }

--- a/backend/src/test/java/team7/inplace/place/persistence/PlaceReadRepositoryTest.java
+++ b/backend/src/test/java/team7/inplace/place/persistence/PlaceReadRepositoryTest.java
@@ -284,11 +284,11 @@ class PlaceReadRepositoryTest extends AbstractMySQLContainerTest {
         Double latitude = 37.0;
         Pageable pageable = PageRequest.of(0, 5);
         Long userId = null;
-        List<String> influencerName = List.of("인플루언서1");
+        List<String> influencerName = List.of("인플루언서2");
 
         final int expectedTotalContent = 4;
         final int expectedContentSize = 4;
-        final List<Long> expectedPlaceIds = List.of(1L, 2L, 3L, 4L);
+        final List<Long> expectedPlaceIds = List.of(5L, 6L, 7L, 8L);
 
         // when
         Page<DetailedPlace> places = placeReadRepository.findPlacesInMapRangeWithPaging(
@@ -316,11 +316,11 @@ class PlaceReadRepositoryTest extends AbstractMySQLContainerTest {
         Double latitude = 37.0;
         Pageable pageable = PageRequest.of(0, 5);
         Long userId = null;
-        List<String> influencerName = List.of("인플루언서1", "인플루언서2");
+        List<String> influencerName = List.of("인플루언서2", "인플루언서3");
 
         final int expectedTotalContent = 8;
         final int expectedContentSize = 5;
-        final List<Long> expectedPlaceIds = List.of(1L, 2L, 3L, 4L, 5L);
+        final List<Long> expectedPlaceIds = List.of(5L, 6L, 7L, 8L, 9L);
 
         // when
         Page<DetailedPlace> places = placeReadRepository.findPlacesInMapRangeWithPaging(

--- a/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
+++ b/backend/src/test/java/team7/inplace/video/persistence/VideoReadRepositoryTest.java
@@ -3,7 +3,6 @@ package team7.inplace.video.persistence;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,8 +116,8 @@ public class VideoReadRepositoryTest {
     @DisplayName("비디오 조회 테스트 - 특정 장소의 비디오 조회")
     void findVideo_PlaceInfo() {
         // given
-        final int expectedTotalContent = 1;
-        final List<Long> expectedVideoIds = List.of(1L);
+        final int expectedTotalContent = 3;
+        final List<Long> expectedVideoIds = List.of(1L, 2L, 3L);
 
         // when
         List<VideoQueryResult.SimpleVideo> videos = videoReadRepository.findSimpleVideosByPlaceId(1L);
@@ -174,11 +173,11 @@ public class VideoReadRepositoryTest {
     @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 기본(날짜 순) 정렬")
     void findVideo_InfluencerId() {
         // given
-        Pageable pageable = PageRequest.of(0, 5);
+        Pageable pageable = PageRequest.of(0, 15);
 
-        final int expectedTotalContent = 4;
-        final int expectedContentSize = 4;
-        final List<Long> expectedVideoIds = List.of(4L, 3L, 2L, 1L);
+        final int expectedTotalContent = 10;
+        final int expectedContentSize = 10;
+        final List<Long> expectedVideoIds = List.of(4L, 3L, 3L, 3L, 2L, 2L, 2L, 1L, 1L, 1L);
 
         // when
         Page<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findDetailedVideosWithOneInfluencerId(
@@ -195,11 +194,11 @@ public class VideoReadRepositoryTest {
     @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 인기순(조회수 증가량) 정렬")
     void findVideo_InfluencerId_popularity() {
         // given
-        Pageable pageable = PageRequest.of(0, 5, Sort.by("popularity"));
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("popularity"));
 
-        final int expectedTotalContent = 4;
-        final int expectedContentSize = 4;
-        final List<Long> expectedVideoIds = List.of(4L, 3L, 2L, 1L);
+        final int expectedTotalContent = 10;
+        final int expectedContentSize = 10;
+        final List<Long> expectedVideoIds = List.of(4L, 3L, 3L, 3L, 2L, 2L, 2L, 1L, 1L, 1L);
 
         // when
         Page<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findDetailedVideosWithOneInfluencerId(
@@ -216,11 +215,11 @@ public class VideoReadRepositoryTest {
     @DisplayName("비디오 조회 테스트 - 인플루언서 id를 통해 비디오 조회 - 장소 좋아요순 정렬")
     void findVideo_InfluencerId_likes() {
         // given
-        Pageable pageable = PageRequest.of(0, 5, Sort.by("likes"));
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("likes"));
 
-        final int expectedTotalContent = 4;
-        final int expectedContentSize = 4;
-        final List<Long> expectedVideoIds = List.of(3L, 2L, 1L, 4L);
+        final int expectedTotalContent = 10;
+        final int expectedContentSize = 10;
+        final List<Long> expectedVideoIds = List.of(3L, 2L, 1L, 3L, 2L, 1L, 3L, 2L, 1L, 4L);
 
         // when
         Page<VideoQueryResult.DetailedVideo> videos = videoReadRepository.findDetailedVideosWithOneInfluencerId(

--- a/backend/src/test/resources/sql/test-influencer.sql
+++ b/backend/src/test/resources/sql/test-influencer.sql
@@ -1,8 +1,8 @@
-INSERT INTO influencers (id, name, job, channel_id, img_url)
-VALUES (1, '인플루언서1', '직업1', 'channel1', 'img1'),
-       (2, '인플루언서2', '직업2', 'channel2', 'img2'),
-       (3, '인플루언서3', '직업3', 'channel3', 'img3'),
-       (4, '인플루언서4', '직업4', 'channel4', 'img4');
+INSERT INTO influencers (id, name, job, channel_id, img_url, hidden)
+VALUES (1, '인플루언서1', '직업1', 'channel1', 'img1', 0),
+       (2, '인플루언서2', '직업2', 'channel2', 'img2', 0),
+       (3, '인플루언서3', '직업3', 'channel3', 'img3', 0),
+       (4, '인플루언서4', '직업4', 'channel4', 'img4', 0);
 
 INSERT INTO categories(id, name, eng_name, parent_id)
 VALUES (1, '맛집', 'eats', null),


### PR DESCRIPTION
### ✨ 작업 내용
- 인플루언서 페이지에서 비디오 정렬 조건(인기순, 좋아요순)이 같으면 최신순으로 정렬되도록 조건 추가했습니다.
- 비디오 삭제 시 soft delete로 삭제되도록 수정하였고, 비디오 조회 시 soft delete 제외하고 조회하도록 했습니다.
- 인플루언서 숨김 처리한 거 반영되도록 조회 수정했습니다.

---

### ✨ 참고 사항
- pr 확인되면 videos 테이블 delete_at에 인덱스 만들겠습니다!

---

### ⏰ 현재 버그

---

### ✏ Git Close
