### PR TITLE
[INPLACE-253] 신고 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // OpenAI
+    implementation platform("org.springframework.ai:spring-ai-bom:1.0.0")
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/team7/inplace/global/config/AsyncConfig.java
+++ b/backend/src/main/java/team7/inplace/global/config/AsyncConfig.java
@@ -22,4 +22,17 @@ public class AsyncConfig {
         return executor;
     }
 
+    @Bean(name = "aiExecutor")
+    public Executor aiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(30);
+        executor.setThreadNamePrefix("ai-");
+        executor.setTaskDecorator(new ThreadContextPropagatingDecorator());
+        executor.initialize();
+        
+        return executor;
+    }
+
 }

--- a/backend/src/main/java/team7/inplace/post/application/PostService.java
+++ b/backend/src/main/java/team7/inplace/post/application/PostService.java
@@ -188,6 +188,15 @@ public class PostService {
         post.deleteSoftly();
     }
 
+    @Transactional
+    public void reportPost(Long postId) {
+        var post = postJpaRepository.findById(postId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.POST_NOT_FOUND));
+        if (!Boolean.TRUE.equals(post.getIsReported())) {
+            post.report();
+        }
+    }
+
     @Transactional(readOnly = true)
     public String getCommentContentById(Long commentId) {
         return commentJpaRepository.findContentById(commentId)
@@ -202,6 +211,15 @@ public class PostService {
             throw InplaceException.of(PostErrorCode.POST_NOT_FOUND);
         }
         comment.deleteSoftly();
+    }
+
+    @Transactional
+    public void reportComment(Long commentId) {
+        var comment = commentJpaRepository.findById(commentId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.COMMENT_NOT_FOUND));
+        if (!Boolean.TRUE.equals(comment.getIsReported())) {
+            comment.report();
+        }
     }
 
 }

--- a/backend/src/main/java/team7/inplace/post/application/PostService.java
+++ b/backend/src/main/java/team7/inplace/post/application/PostService.java
@@ -174,4 +174,34 @@ public class PostService {
             .toList();
 
     }
+
+    @Transactional(readOnly = true)
+    public String getPostContentById(Long postId) {
+        return postJpaRepository.findContentById(postId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.POST_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deletePostSoftly(Long postId) {
+        var post = postJpaRepository.findById(postId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.POST_NOT_FOUND));
+        post.deleteSoftly();
+    }
+
+    @Transactional(readOnly = true)
+    public String getCommentContentById(Long commentId) {
+        return commentJpaRepository.findContentById(commentId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deleteCommentSoftly(Long commentId) {
+        var comment = commentJpaRepository.findById(commentId)
+            .orElseThrow(() -> InplaceException.of(PostErrorCode.COMMENT_NOT_FOUND));
+        if (!postJpaRepository.existsById(comment.getPostId())) {
+            throw InplaceException.of(PostErrorCode.POST_NOT_FOUND);
+        }
+        comment.deleteSoftly();
+    }
+
 }

--- a/backend/src/main/java/team7/inplace/post/application/PostService.java
+++ b/backend/src/main/java/team7/inplace/post/application/PostService.java
@@ -192,9 +192,7 @@ public class PostService {
     public void reportPost(Long postId) {
         var post = postJpaRepository.findById(postId)
             .orElseThrow(() -> InplaceException.of(PostErrorCode.POST_NOT_FOUND));
-        if (!Boolean.TRUE.equals(post.getIsReported())) {
-            post.report();
-        }
+        post.report();
     }
 
     @Transactional(readOnly = true)
@@ -217,9 +215,7 @@ public class PostService {
     public void reportComment(Long commentId) {
         var comment = commentJpaRepository.findById(commentId)
             .orElseThrow(() -> InplaceException.of(PostErrorCode.COMMENT_NOT_FOUND));
-        if (!Boolean.TRUE.equals(comment.getIsReported())) {
-            comment.report();
-        }
+        comment.report();
     }
 
 }

--- a/backend/src/main/java/team7/inplace/post/domain/Comment.java
+++ b/backend/src/main/java/team7/inplace/post/domain/Comment.java
@@ -3,11 +3,13 @@ package team7.inplace.post.domain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team7.inplace.global.baseEntity.BaseEntity;
 import team7.inplace.global.exception.InplaceException;
 import team7.inplace.global.exception.code.PostErrorCode;
 
+@Getter
 @Entity
 @Table(name = "comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/team7/inplace/post/domain/Comment.java
+++ b/backend/src/main/java/team7/inplace/post/domain/Comment.java
@@ -19,6 +19,7 @@ public class Comment extends BaseEntity {
     private Long authorId;
     private String content;
     private Integer totalLikeCount = 0;
+    private Boolean isReported = false;
 
     public Comment(Long postId, Long authorId, String content) {
         validateContent(content);
@@ -54,6 +55,10 @@ public class Comment extends BaseEntity {
             return;
         }
         throw InplaceException.of(PostErrorCode.COMMENT_CAN_NOT_BE_MODIFIED);
+    }
+
+    public void report() {
+        this.isReported = true;
     }
 
 }

--- a/backend/src/main/java/team7/inplace/post/domain/Comment.java
+++ b/backend/src/main/java/team7/inplace/post/domain/Comment.java
@@ -58,7 +58,9 @@ public class Comment extends BaseEntity {
     }
 
     public void report() {
-        this.isReported = true;
+        if (!Boolean.TRUE.equals(this.isReported)) {
+            this.isReported = true;
+        }
     }
 
 }

--- a/backend/src/main/java/team7/inplace/post/domain/Post.java
+++ b/backend/src/main/java/team7/inplace/post/domain/Post.java
@@ -5,12 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team7.inplace.global.baseEntity.BaseEntity;
 import team7.inplace.global.exception.InplaceException;
 import team7.inplace.global.exception.code.PostErrorCode;
 
 @Entity
+@Getter
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
@@ -24,6 +26,7 @@ public class Post extends BaseEntity {
     private Integer totalLikeCount;
     private Integer totalCommentCount;
     private Long authorId;
+    private Boolean isReported = false;
 
     public Post(
         String title, String content,
@@ -77,5 +80,9 @@ public class Post extends BaseEntity {
             return;
         }
         throw InplaceException.of(PostErrorCode.POST_CAN_NOT_BE_MODIFIED);
+    }
+
+    public void report() {
+        this.isReported = true;
     }
 }

--- a/backend/src/main/java/team7/inplace/post/domain/Post.java
+++ b/backend/src/main/java/team7/inplace/post/domain/Post.java
@@ -83,6 +83,8 @@ public class Post extends BaseEntity {
     }
 
     public void report() {
-        this.isReported = true;
+        if (!Boolean.TRUE.equals(this.isReported)) {
+            this.isReported = true;
+        }
     }
 }

--- a/backend/src/main/java/team7/inplace/post/persistence/CommentJpaRepository.java
+++ b/backend/src/main/java/team7/inplace/post/persistence/CommentJpaRepository.java
@@ -1,8 +1,10 @@
 package team7.inplace.post.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team7.inplace.post.domain.Comment;
 
@@ -16,4 +18,7 @@ public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("UPDATE Comment c SET c.totalLikeCount = c.totalLikeCount - 1 WHERE c.id = :commentId")
     void decreaseLikeCount(Long commentId);
+
+    @Query("SELECT c.content FROM Comment c WHERE c.id = :commentId")
+    Optional<String> findContentById(@Param("commentId") Long commentId);
 }

--- a/backend/src/main/java/team7/inplace/post/persistence/PostJpaRepository.java
+++ b/backend/src/main/java/team7/inplace/post/persistence/PostJpaRepository.java
@@ -1,8 +1,10 @@
 package team7.inplace.post.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team7.inplace.post.domain.Post;
 
@@ -24,4 +26,7 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("update Post p set p.totalCommentCount = p.totalCommentCount - 1 where p.id = :postId")
     void decreaseCommentCount(Long postId);
+
+    @Query("SELECT p.content.content FROM Post p WHERE p.id = :postId")
+    Optional<String> findContentById(@Param("postId") Long postId);
 }

--- a/backend/src/main/java/team7/inplace/report/application/ModerationService.java
+++ b/backend/src/main/java/team7/inplace/report/application/ModerationService.java
@@ -1,0 +1,20 @@
+package team7.inplace.report.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.moderation.ModerationPrompt;
+import org.springframework.ai.moderation.ModerationResponse;
+import org.springframework.ai.openai.OpenAiModerationModel;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ModerationService {
+
+    private final OpenAiModerationModel moderationModel;
+
+    public boolean isContentFlagged(String content) {
+        ModerationPrompt prompt = new ModerationPrompt(content);
+        ModerationResponse response = moderationModel.call(prompt);
+        return response.getResults().get(0).getOutput().getResults().get(0).isFlagged();
+    }
+}

--- a/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
+++ b/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
@@ -1,0 +1,31 @@
+package team7.inplace.report.application;
+
+import lombok.RequiredArgsConstructor;
+import team7.inplace.global.annotation.Facade;
+import team7.inplace.post.application.PostService;
+
+@Facade
+@RequiredArgsConstructor
+public class ReportFacade {
+
+    private final PostService postService;
+    private final ModerationService moderationService;
+
+    public void processPostReport(Long postId) {
+        String content = postService.getPostContentById(postId);
+        boolean flag = moderationService.isContentFlagged(content);
+        if (flag) {
+            postService.deletePostSoftly(postId);
+        }
+    }
+
+    public void processCommentReport(Long commentId) {
+        String content = postService.getCommentContentById(commentId);
+        boolean flag = moderationService.isContentFlagged(content);
+        if (flag) {
+            postService.deleteCommentSoftly(commentId);
+        }
+    }
+
+
+}

--- a/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
+++ b/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
@@ -3,6 +3,7 @@ package team7.inplace.report.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import team7.inplace.global.annotation.Facade;
+import team7.inplace.post.application.PostService;
 import team7.inplace.report.event.ReportEvent.CommentReportEvent;
 import team7.inplace.report.event.ReportEvent.PostReportEvent;
 
@@ -10,12 +11,15 @@ import team7.inplace.report.event.ReportEvent.PostReportEvent;
 @RequiredArgsConstructor
 public class ReportFacade {
     private final ApplicationEventPublisher eventPublisher;
+    private final PostService postService;
 
     public void processPostReport(Long postId) {
+        postService.reportPost(postId);
         eventPublisher.publishEvent(new PostReportEvent(postId));
     }
 
     public void processCommentReport(Long commentId) {
+        postService.reportComment(commentId);
         eventPublisher.publishEvent(new CommentReportEvent(commentId));
     }
 

--- a/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
+++ b/backend/src/main/java/team7/inplace/report/application/ReportFacade.java
@@ -1,31 +1,22 @@
 package team7.inplace.report.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import team7.inplace.global.annotation.Facade;
-import team7.inplace.post.application.PostService;
+import team7.inplace.report.event.ReportEvent.CommentReportEvent;
+import team7.inplace.report.event.ReportEvent.PostReportEvent;
 
 @Facade
 @RequiredArgsConstructor
 public class ReportFacade {
-
-    private final PostService postService;
-    private final ModerationService moderationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public void processPostReport(Long postId) {
-        String content = postService.getPostContentById(postId);
-        boolean flag = moderationService.isContentFlagged(content);
-        if (flag) {
-            postService.deletePostSoftly(postId);
-        }
+        eventPublisher.publishEvent(new PostReportEvent(postId));
     }
 
     public void processCommentReport(Long commentId) {
-        String content = postService.getCommentContentById(commentId);
-        boolean flag = moderationService.isContentFlagged(content);
-        if (flag) {
-            postService.deleteCommentSoftly(commentId);
-        }
+        eventPublisher.publishEvent(new CommentReportEvent(commentId));
     }
-
 
 }

--- a/backend/src/main/java/team7/inplace/report/application/event/ReportEventHandler.java
+++ b/backend/src/main/java/team7/inplace/report/application/event/ReportEventHandler.java
@@ -1,0 +1,38 @@
+package team7.inplace.report.application.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import team7.inplace.post.application.PostService;
+import team7.inplace.report.application.ModerationService;
+import team7.inplace.report.event.ReportEvent.CommentReportEvent;
+import team7.inplace.report.event.ReportEvent.PostReportEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ReportEventHandler {
+
+    private final PostService postService;
+    private final ModerationService moderationService;
+
+    @Async("aiExecutor")
+    @EventListener
+    public void processPostReport(PostReportEvent event) {
+        String content = postService.getPostContentById(event.postId());
+        boolean flag = moderationService.isContentFlagged(content);
+        if (flag) {
+            postService.deletePostSoftly(event.postId());
+        }
+    }
+
+    @Async("aiExecutor")
+    @EventListener
+    public void processCommentReport(CommentReportEvent event) {
+        String content = postService.getCommentContentById(event.commentId());
+        boolean flag = moderationService.isContentFlagged(content);
+        if (flag) {
+            postService.deleteCommentSoftly(event.commentId());
+        }
+    }
+}

--- a/backend/src/main/java/team7/inplace/report/event/ReportEvent.java
+++ b/backend/src/main/java/team7/inplace/report/event/ReportEvent.java
@@ -1,0 +1,9 @@
+package team7.inplace.report.event;
+
+public class ReportEvent {
+
+    public record PostReportEvent(Long postId) {}
+
+    public record CommentReportEvent(Long commentId) {}
+
+}

--- a/backend/src/main/java/team7/inplace/report/presentation/ReportController.java
+++ b/backend/src/main/java/team7/inplace/report/presentation/ReportController.java
@@ -1,0 +1,36 @@
+package team7.inplace.report.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team7.inplace.report.application.ReportFacade;
+import team7.inplace.report.presentation.dto.ReportRequest.SubmitReport;
+
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+public class ReportController implements ReportControllerApiSpec {
+
+    private final ReportFacade reportFacade;
+
+    @Override
+    @PostMapping("/post")
+    public ResponseEntity<Void> submitPostReport(@RequestBody SubmitReport request) {
+        reportFacade.processPostReport(request.id());
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Override
+    @PostMapping("/comment")
+    public ResponseEntity<Void> submitCommentReport(@RequestBody SubmitReport request) {
+        reportFacade.processCommentReport(request.id());
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/backend/src/main/java/team7/inplace/report/presentation/ReportControllerApiSpec.java
+++ b/backend/src/main/java/team7/inplace/report/presentation/ReportControllerApiSpec.java
@@ -1,0 +1,17 @@
+package team7.inplace.report.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.http.ResponseEntity;
+import team7.inplace.report.presentation.dto.ReportRequest.SubmitReport;
+
+
+public interface ReportControllerApiSpec {
+
+    @Operation(summary = "게시글 신고 요청", description = "게시글 신고 요청을 처리합니다.")
+    ResponseEntity<Void> submitPostReport(@RequestBody SubmitReport request);
+
+    @Operation(summary = "댓글 신고 요청", description = "댓글 신고 요청을 처리합니다.")
+    ResponseEntity<Void> submitCommentReport(@RequestBody SubmitReport request);
+
+}

--- a/backend/src/main/java/team7/inplace/report/presentation/dto/ReportRequest.java
+++ b/backend/src/main/java/team7/inplace/report/presentation/dto/ReportRequest.java
@@ -1,0 +1,12 @@
+package team7.inplace.report.presentation.dto;
+
+public class ReportRequest {
+
+    public record SubmitReport (
+        Long id,
+        String reason
+    ) {
+
+    }
+
+}

--- a/backend/src/main/resources/application-openai.yaml
+++ b/backend/src/main/resources/application-openai.yaml
@@ -1,0 +1,3 @@
+openai:
+  api:
+    key: ${OPENAI_API_KEY}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -70,3 +70,8 @@ logging:
 springdoc:
   swagger-ui:
     enabled: false
+---
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}

--- a/backend/src/test/java/team7/inplace/report/ReportEventHandlerTest.java
+++ b/backend/src/test/java/team7/inplace/report/ReportEventHandlerTest.java
@@ -1,0 +1,71 @@
+package team7.inplace.report;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.EnableAsync;
+import team7.inplace.post.application.PostService;
+import team7.inplace.report.application.ModerationService;
+import team7.inplace.report.event.ReportEvent.CommentReportEvent;
+import team7.inplace.report.event.ReportEvent.PostReportEvent;
+
+@SpringBootTest
+@EnableAsync
+public class ReportEventHandlerTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @MockBean
+    private PostService postService;
+
+    @MockBean
+    private ModerationService moderationService;
+
+    @Test
+    @DisplayName("게시글 이벤트 리스너 테스트")
+    void postReportEventListenerTest() {
+        // given
+        Long postId = 1L;
+        String content = "유해 콘텐츠";
+        given(postService.getPostContentById(postId)).willReturn(content);
+        given(moderationService.isContentFlagged(content)).willReturn(true);
+
+        // when
+        eventPublisher.publishEvent(new PostReportEvent(postId));
+
+        // then
+        await().atMost(5, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                verify(postService).deletePostSoftly(postId);
+            });
+    }
+
+    @Test
+    @DisplayName("댓글 이벤트 리스너 테스트")
+    void commentReportEventListenerTest() {
+        // given
+        Long commentId = 1L;
+        String content = "유해 콘텐츠";
+        given(postService.getCommentContentById(commentId)).willReturn(content);
+        given(moderationService.isContentFlagged(content)).willReturn(true);
+
+        // when
+        eventPublisher.publishEvent(new CommentReportEvent(commentId));
+
+        // then
+        await().atMost(5, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                verify(postService).deleteCommentSoftly(commentId);
+            });
+    }
+
+}


### PR DESCRIPTION
### ✨ 작업 내용
- 게시글/ 댓글 신고 요청시 openai의 moderation ai(유해한 콘텐츠 식별용 ai)를 활용해 flag가 true면 soft delete 처리했습니다.

---

### ✨ 참고 사항
- 신고 기능에 대해 생각해봤는데, 아래 내용 중 1번을 구현한 상태이고, 2,3,4 개발에 대해 의논이 필요할 거 같습니다. 

  > 1. 사용자가 게시글 신고 후 -> ai가 검열
  > 2. Ai 판단 애매한 경우 -> 관리자가 추가 확인 필요
  > 3. (선택) 신고 후 결과(삭제 or 복구)를 신고자와 작성자에게 안내
  > 4. (선택) 제재 정책 (ex. 3회 이상 신고당하면 한달 이용 제한 등)
  - 3번을 구현한다면 신고 테이블이 필요할 거 같고 아니라면 필드 추가로 처리할 수 있을 듯합니다.

- 테스트해보니까 영어에 비해 한국어에 대해 기준이 널널한 거 같아서 번역해서 판단시키거나 gpt 사용하는 걸로 변경하면 개선될 듯합니다
---

### ⏰ 현재 버그

---

### ✏ Git Close
