### PR TITLE
[INPLACE-254] 좋아요/댓글 비정규화 처리

### DIFF
--- a/backend/src/main/java/team7/inplace/liked/likedComment/domain/LikedComment.java
+++ b/backend/src/main/java/team7/inplace/liked/likedComment/domain/LikedComment.java
@@ -1,4 +1,4 @@
-package team7.inplace.liked.likedComment;
+package team7.inplace.liked.likedComment.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -15,9 +15,20 @@ public class LikedComment extends BaseEntity {
 
     private Long userId;
     private Long commentId;
+    private Boolean isLiked;
 
     public LikedComment(Long userId, Long commentId) {
         this.userId = userId;
         this.commentId = commentId;
+        this.isLiked = false;
+    }
+
+    public static LikedComment from(Long userId, Long commentId) {
+        return new LikedComment(userId, commentId);
+    }
+
+    public boolean updateLike() {
+        this.isLiked = !this.isLiked;
+        return this.isLiked;
     }
 }

--- a/backend/src/main/java/team7/inplace/liked/likedComment/persistence/LikedCommentRepository.java
+++ b/backend/src/main/java/team7/inplace/liked/likedComment/persistence/LikedCommentRepository.java
@@ -1,0 +1,10 @@
+package team7.inplace.liked.likedComment.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import team7.inplace.liked.likedComment.domain.LikedComment;
+
+public interface LikedCommentRepository extends JpaRepository<LikedComment, Long> {
+
+    Optional<LikedComment> findByUserIdAndCommentId(Long userId, Long commentId);
+}

--- a/backend/src/main/java/team7/inplace/liked/likedPost/domain/LikedPost.java
+++ b/backend/src/main/java/team7/inplace/liked/likedPost/domain/LikedPost.java
@@ -13,9 +13,20 @@ public class LikedPost extends BaseEntity {
 
     private Long userId;
     private Long postId;
+    private Boolean isLiked;
 
-    public LikedPost(Long userId, Long postId) {
+    private LikedPost(Long userId, Long postId) {
         this.userId = userId;
         this.postId = postId;
+        this.isLiked = false;
+    }
+
+    public static LikedPost from(Long userId, Long postId) {
+        return new LikedPost(userId, postId);
+    }
+
+    public boolean updateLike() {
+        this.isLiked = !this.isLiked;
+        return this.isLiked;
     }
 }

--- a/backend/src/main/java/team7/inplace/liked/likedPost/persistence/LikedPostRepository.java
+++ b/backend/src/main/java/team7/inplace/liked/likedPost/persistence/LikedPostRepository.java
@@ -1,0 +1,12 @@
+package team7.inplace.liked.likedPost.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team7.inplace.liked.likedPost.domain.LikedPost;
+
+@Repository
+public interface LikedPostRepository extends JpaRepository<LikedPost, Long> {
+
+    Optional<LikedPost> findByUserIdAndPostId(Long userId, Long postId);
+}

--- a/backend/src/main/java/team7/inplace/post/persistence/CommentJpaRepository.java
+++ b/backend/src/main/java/team7/inplace/post/persistence/CommentJpaRepository.java
@@ -1,10 +1,19 @@
 package team7.inplace.post.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import team7.inplace.post.domain.Comment;
 
 @Repository
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
+    @Modifying
+    @Query("UPDATE Comment c SET c.totalLikeCount = c.totalLikeCount + 1 WHERE c.id = :commentId")
+    void increaseLikeCount(Long commentId);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.totalLikeCount = c.totalLikeCount - 1 WHERE c.id = :commentId")
+    void decreaseLikeCount(Long commentId);
 }

--- a/backend/src/main/java/team7/inplace/post/persistence/PostJpaRepository.java
+++ b/backend/src/main/java/team7/inplace/post/persistence/PostJpaRepository.java
@@ -1,10 +1,27 @@
 package team7.inplace.post.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import team7.inplace.post.domain.Post;
 
 @Repository
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
 
+    @Modifying
+    @Query("update Post p set p.totalLikeCount = p.totalLikeCount + 1 where p.id = :postId")
+    void increaseLikeCount(Long postId);
+
+    @Modifying
+    @Query("update Post p set p.totalLikeCount = p.totalLikeCount - 1 where p.id = :postId")
+    void decreaseLikeCount(Long postId);
+
+    @Modifying
+    @Query("update Post p set p.totalCommentCount = p.totalCommentCount + 1 where p.id = :postId")
+    void increaseCommentCount(Long postId);
+
+    @Modifying
+    @Query("update Post p set p.totalCommentCount = p.totalCommentCount - 1 where p.id = :postId")
+    void decreaseCommentCount(Long postId);
 }


### PR DESCRIPTION
### ✨ 작업 내용

- 댓글 달리고 삭제될 때 비정규화 column을 update합니다.
- 댓글/게시글 좋아요/안좋아요 시 비정규화 column을 update합니다.
---

### ✨ 참고 사항

- 동시성 문제를 해결하기 위해 UPDATE 쿼리를 직접 날리는 방식을 사용했습니다.
- 다른방법이 있으면 코멘트 부탁드립니다
---

### ⏰ 현재 버그

---

### ✏ Git Close
